### PR TITLE
Issue #57: Update LP3 logic for 21-29 years olds to accomodate messy data

### DIFF
--- a/test/ScreeningImmunocompromised/cases/Under30HasCotestNeedsImmediateSecondTest.yml
+++ b/test/ScreeningImmunocompromised/cases/Under30HasCotestNeedsImmediateSecondTest.yml
@@ -1,0 +1,48 @@
+---
+name: Under 30 and need immediate cytology test number 2 after previous cotest
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: Condition
+  clinicalStatus: http://terminology.hl7.org/CodeSystem/condition-clinical#active Active
+  verificationStatus: http://terminology.hl7.org/CodeSystem/condition-ver-status#confirmed Confirmed
+  code: SNOMEDCT#186706006 Human immunodeficiency virus infection constitutional disease (disorder)
+  onsetDateTime: 2017-05-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+  status: amended
+  conclusionCode:
+  - SNOMEDCT#373887005 Negative for intraepithelial lesion or malignancy (finding)
+  effectiveDateTime: 2020-05-01
+-
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2020-05-01
+
+results:
+  IsIncludedAndNotExcluded: true
+  DateOfFirstNilmCytologyAfterImmunosuppressionOnset: '2020-05-01T00:00:00.000+00:00'
+  DateOfSecondNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfThirdNilmCytologyAfterImmunosuppressionOnset: null
+  NeedFirstOfThreeAnnualCytologyTests: false
+  NeedSecondOfThreeAnnualCytologyTests: true
+  NeedThirdOfThreeAnnualCytologyTests: false
+  TestingCadence:
+    value: 12
+    unit: months
+  ProposedDateOfNextScreening: '2021-06-23T00:00:00.000+00:00'
+  RecommendImmediateCervicalCytology: true
+  RecommendImmediateCotesting: false

--- a/test/ScreeningImmunocompromised/cases/Under30HasHPVTestNeedsImmediateFirstTest.yml
+++ b/test/ScreeningImmunocompromised/cases/Under30HasHPVTestNeedsImmediateFirstTest.yml
@@ -1,0 +1,41 @@
+---
+name: Under 30 and need immediate cytology test number 1 after previous HPV test
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: Condition
+  clinicalStatus: http://terminology.hl7.org/CodeSystem/condition-clinical#active Active
+  verificationStatus: http://terminology.hl7.org/CodeSystem/condition-ver-status#confirmed Confirmed
+  code: SNOMEDCT#186706006 Human immunodeficiency virus infection constitutional disease (disorder)
+  onsetDateTime: 2017-05-01
+-
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2020-05-01
+
+results:
+  IsIncludedAndNotExcluded: true
+  DateOfFirstNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfSecondNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfThirdNilmCytologyAfterImmunosuppressionOnset: null
+  NeedFirstOfThreeAnnualCytologyTests: true
+  NeedSecondOfThreeAnnualCytologyTests: false
+  NeedThirdOfThreeAnnualCytologyTests: false
+  TestingCadence:
+    value: 12
+    unit: months
+  ProposedDateOfNextScreening: '2021-06-23T00:00:00.000+00:00'
+  RecommendImmediateCervicalCytology: true
+  RecommendImmediateCotesting: false

--- a/test/ScreeningImmunocompromised/cases/Under30withFirstCotest.yml
+++ b/test/ScreeningImmunocompromised/cases/Under30withFirstCotest.yml
@@ -1,0 +1,48 @@
+---
+name: Under 30 and need cytology test number 2 after cotest
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: Condition
+  clinicalStatus: http://terminology.hl7.org/CodeSystem/condition-clinical#active Active
+  verificationStatus: http://terminology.hl7.org/CodeSystem/condition-ver-status#confirmed Confirmed
+  code: SNOMEDCT#186706006 Human immunodeficiency virus infection constitutional disease (disorder)
+  onsetDateTime: 2017-05-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+  status: amended
+  conclusionCode:
+  - SNOMEDCT#373887005 Negative for intraepithelial lesion or malignancy (finding)
+  effectiveDateTime: 2021-05-01
+-
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2021-05-01
+
+results:
+  IsIncludedAndNotExcluded: true
+  DateOfFirstNilmCytologyAfterImmunosuppressionOnset: '2021-05-01T00:00:00.000+00:00'
+  DateOfSecondNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfThirdNilmCytologyAfterImmunosuppressionOnset: null
+  NeedFirstOfThreeAnnualCytologyTests: false
+  NeedSecondOfThreeAnnualCytologyTests: true
+  NeedThirdOfThreeAnnualCytologyTests: false
+  TestingCadence:
+    value: 12
+    unit: months
+  ProposedDateOfNextScreening: '2022-05-01T00:00:00.000+00:00'
+  RecommendImmediateCervicalCytology: false
+  RecommendImmediateCotesting: false

--- a/test/ScreeningImmunocompromised/cases/Under30withFirstCytologyTest.yml
+++ b/test/ScreeningImmunocompromised/cases/Under30withFirstCytologyTest.yml
@@ -1,0 +1,41 @@
+---
+name: Under 30 and need cytology test number 2 after cytology test
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: Condition
+  clinicalStatus: http://terminology.hl7.org/CodeSystem/condition-clinical#active Active
+  verificationStatus: http://terminology.hl7.org/CodeSystem/condition-ver-status#confirmed Confirmed
+  code: SNOMEDCT#186706006 Human immunodeficiency virus infection constitutional disease (disorder)
+  onsetDateTime: 2017-05-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+  status: amended
+  conclusionCode:
+  - SNOMEDCT#373887005 Negative for intraepithelial lesion or malignancy (finding)
+  effectiveDateTime: 2021-05-01
+
+results:
+  IsIncludedAndNotExcluded: true
+  DateOfFirstNilmCytologyAfterImmunosuppressionOnset: '2021-05-01T00:00:00.000+00:00'
+  DateOfSecondNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfThirdNilmCytologyAfterImmunosuppressionOnset: null
+  NeedFirstOfThreeAnnualCytologyTests: false
+  NeedSecondOfThreeAnnualCytologyTests: true
+  NeedThirdOfThreeAnnualCytologyTests: false
+  TestingCadence:
+    value: 12
+    unit: months
+  ProposedDateOfNextScreening: '2022-05-01T00:00:00.000+00:00'
+  RecommendImmediateCervicalCytology: false
+  RecommendImmediateCotesting: false

--- a/test/ScreeningImmunocompromised/cases/Under30withFirstHPVTest.yml
+++ b/test/ScreeningImmunocompromised/cases/Under30withFirstHPVTest.yml
@@ -1,0 +1,41 @@
+---
+name: Under 30 and need cytology test number 1 after HPV test
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: Condition
+  clinicalStatus: http://terminology.hl7.org/CodeSystem/condition-clinical#active Active
+  verificationStatus: http://terminology.hl7.org/CodeSystem/condition-ver-status#confirmed Confirmed
+  code: SNOMEDCT#186706006 Human immunodeficiency virus infection constitutional disease (disorder)
+  onsetDateTime: 2017-05-01
+-
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2021-05-01
+
+results:
+  IsIncludedAndNotExcluded: true
+  DateOfFirstNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfSecondNilmCytologyAfterImmunosuppressionOnset: null
+  DateOfThirdNilmCytologyAfterImmunosuppressionOnset: null
+  NeedFirstOfThreeAnnualCytologyTests: true
+  NeedSecondOfThreeAnnualCytologyTests: false
+  NeedThirdOfThreeAnnualCytologyTests: false
+  TestingCadence:
+    value: 12
+    unit: months
+  ProposedDateOfNextScreening: '2021-06-23T00:00:00.000+00:00'
+  RecommendImmediateCervicalCytology: true
+  RecommendImmediateCotesting: false


### PR DESCRIPTION
Tests for Issue #57: I added 5 test cases to test situations where an immunocompromised patient who is under 29 receives a cotest or an HPV test, to make sure our CDS is behaving appropriately.