### PR TITLE
Add support for Hysterectomy without date #66

### DIFF
--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -729,7 +729,7 @@ define RecommendationForManagingPatientsAfterHysterectomy:
     ) then 
       {
         short: 'See Details',
-        date: Collate.DateOfMostRecentReport + 3 years,
+        date: Today(),
         group: 'Hysterectomy (K.4)',
         details: {
           'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment of histologic HSIL (CIN 2 or CIN 3), patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.',

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -709,7 +709,7 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         date: ToDate(DateK41),
         group: 'Hysterectomy (K.4)',
         details: {
-          'HPV-based testing (cotest or primary hrHPV test) is recommended annually for 3 years after hysterectomy performed for treatment of CIN 2 or CIN 3.'
+          'HPV-based testing (cotest or primary hrHPV test) is recommended annually for 3 years after hysterectomy performed for treatment of histologic HSIL (CIN 2 or CIN 3).'
         }
       }
     when ( // K4.2
@@ -722,7 +722,7 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Hysterectomy (K.4)',
         details: {
-          'HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years.'
+          'HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years after hysterectomy is performed for treatment of histologic HSIL (CIN 2 or CIN 3).'
         }
       }
     when ( // no hysterectomy date
@@ -733,8 +733,9 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Hysterectomy (K.4)',
         details: {
-          'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment, patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.',
-          'Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.'
+          'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment of histologic HSIL (CIN 2 or CIN 3), patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.',
+          'Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.',
+          'Cancer screening is not recommended for patients who have undergone hysterectomy but have no previous diagnosis of histologic HSIL (CIN 2 or CIN 3), or completed the 25 year long term surveillance.'
         }
       }
     else

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -22,7 +22,6 @@ include DashboardLibrary version '1.0.0' called Dash
 include CollateManagementData version '1.1.0' called Collate
 include ManageRareAbnormality version '1.1.0' called Rare
 include CCSMCommonFunctions version '1.0.0' called CCF
-include ScreeningAverageRiskLibrary version '1.0.0' called SAR
 
 //------------------------------------------------------------------------------
 // CODE SYSTEMS, VALUE SETS, AND CODES
@@ -726,10 +725,10 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         }
       }
     when ( // no hysterectomy date
-      SAR.AbsenceOrRemovalOfCervix
+      Rare.AbsenceOrRemovalOfCervix
     ) then 
       {
-        short: 'Primary HPV or Cotest',
+        short: 'See Details',
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Hysterectomy (K.4)',
         details: {

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -22,6 +22,7 @@ include DashboardLibrary version '1.0.0' called Dash
 include CollateManagementData version '1.1.0' called Collate
 include ManageRareAbnormality version '1.1.0' called Rare
 include CCSMCommonFunctions version '1.0.0' called CCF
+include ScreeningAverageRiskLibrary version '1.0.0' called SAR
 
 //------------------------------------------------------------------------------
 // CODE SYSTEMS, VALUE SETS, AND CODES
@@ -722,6 +723,18 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         group: 'Hysterectomy (K.4)',
         details: {
           'HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years.'
+        }
+      }
+    when ( // no hysterectomy date
+      SAR.AbsenceOrRemovalOfCervix
+    ) then 
+      {
+        short: 'Primary HPV or Cotest',
+        date: Collate.DateOfMostRecentReport + 3 years,
+        group: 'Hysterectomy (K.4)',
+        details: {
+          'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment, patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.',
+          'Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.'
         }
       }
     else

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -48,6 +48,10 @@
             "localIdentifier" : "CCF",
             "path" : "CCSMCommonFunctions",
             "version" : "1.0.0"
+         }, {
+            "localIdentifier" : "SAR",
+            "path" : "ScreeningAverageRiskLibrary",
+            "version" : "1.0.0"
          } ]
       },
       "codeSystems" : {
@@ -4460,6 +4464,58 @@
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "name" : "AbsenceOrRemovalOfCervix",
+                     "libraryName" : "SAR",
+                     "type" : "ExpressionRef"
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Primary HPV or Cotest",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "name" : "DateOfMostRecentReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "value" : 3,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Hysterectomy (K.4)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment, patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.",
                               "type" : "Literal"
                            } ]
                         }

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -48,10 +48,6 @@
             "localIdentifier" : "CCF",
             "path" : "CCSMCommonFunctions",
             "version" : "1.0.0"
-         }, {
-            "localIdentifier" : "SAR",
-            "path" : "ScreeningAverageRiskLibrary",
-            "version" : "1.0.0"
          } ]
       },
       "codeSystems" : {
@@ -4472,7 +4468,7 @@
                }, {
                   "when" : {
                      "name" : "AbsenceOrRemovalOfCervix",
-                     "libraryName" : "SAR",
+                     "libraryName" : "Rare",
                      "type" : "ExpressionRef"
                   },
                   "then" : {
@@ -4481,7 +4477,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Primary HPV or Cotest",
+                           "value" : "See Details",
                            "type" : "Literal"
                         }
                      }, {

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -4392,7 +4392,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "HPV-based testing (cotest or primary hrHPV test) is recommended annually for 3 years after hysterectomy performed for treatment of CIN 2 or CIN 3.",
+                              "value" : "HPV-based testing (cotest or primary hrHPV test) is recommended annually for 3 years after hysterectomy performed for treatment of histologic HSIL (CIN 2 or CIN 3).",
                               "type" : "Literal"
                            } ]
                         }
@@ -4463,7 +4463,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years.",
+                              "value" : "HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years after hysterectomy is performed for treatment of histologic HSIL (CIN 2 or CIN 3).",
                               "type" : "Literal"
                            } ]
                         }
@@ -4511,11 +4511,15 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment, patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.",
+                              "value" : "This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment of histologic HSIL (CIN 2 or CIN 3), patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Cancer screening is not recommended for patients who have undergone hysterectomy but have no previous diagnosis of histologic HSIL (CIN 2 or CIN 3), or completed the 25 year long term surveillance.",
                               "type" : "Literal"
                            } ]
                         }

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -4483,16 +4483,7 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "type" : "Add",
-                           "operand" : [ {
-                              "name" : "DateOfMostRecentReport",
-                              "libraryName" : "Collate",
-                              "type" : "ExpressionRef"
-                           }, {
-                              "value" : 3,
-                              "unit" : "years",
-                              "type" : "Quantity"
-                           } ]
+                           "type" : "Today"
                         }
                      }, {
                         "name" : "group",

--- a/test/ManagementSpecialPopulations/cases/HysterectomyK41.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyK41.yml
@@ -23,5 +23,5 @@ results:
     date: '2022-05-01'
     group: 'Hysterectomy (K.4)'
     details:
-    - 'HPV-based testing (cotest or primary hrHPV test) is recommended annually for 3 years after hysterectomy performed for treatment of CIN 2 or CIN 3.'
+    - 'HPV-based testing (cotest or primary hrHPV test) is recommended annually for 3 years after hysterectomy performed for treatment of histologic HSIL (CIN 2 or CIN 3).'
   WhichPopulationMadeTheRecommendation: 2

--- a/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
@@ -54,5 +54,5 @@ results:
     date: '2024-05-01'
     group: 'Hysterectomy (K.4)'
     details:
-    - 'HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years.'
+    - 'HPV-based testing (cotest or primary hrHPV test) is recommended every 3 years for 25 years after hysterectomy is performed for treatment of histologic HSIL (CIN 2 or CIN 3).'
   WhichPopulationMadeTheRecommendation: 2

--- a/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
@@ -1,0 +1,59 @@
+---
+name: K4.2 Hysterectomy Patient without date
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1995-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#20365006 Squamous intraepithelial neoplasia, grade III (morphologic abnormality)
+  effectiveDateTime: 2018-01-01
+-
+  resourceType: Procedure
+  code: SNOMEDCT#116140006 Total hysterectomy (procedure)
+  status: completed
+  performedDateTime: null
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2019-05-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2020-05-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  status: final
+  conclusionCode:
+  - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
+  effectiveDateTime: 2021-05-01
+
+results:
+  Recommendation: 
+    short: 'Primary HPV or Cotest'
+    date: '2024-05-01'
+    group: 'Hysterectomy (K.4)'
+    details:
+    - 'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment, patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.'
+    - 'Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.'
+  WhichPopulationMadeTheRecommendation: 2

--- a/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
@@ -51,7 +51,7 @@ data:
 results:
   Recommendation: 
     short: 'See Details'
-    date: '2024-05-01'
+    date: '2021-06-02'
     group: 'Hysterectomy (K.4)'
     details:
     - 'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment of histologic HSIL (CIN 2 or CIN 3), patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.'

--- a/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
@@ -50,7 +50,7 @@ data:
 
 results:
   Recommendation: 
-    short: 'Primary HPV or Cotest'
+    short: 'See Details'
     date: '2024-05-01'
     group: 'Hysterectomy (K.4)'
     details:

--- a/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyWithoutDate.yml
@@ -54,6 +54,7 @@ results:
     date: '2024-05-01'
     group: 'Hysterectomy (K.4)'
     details:
-    - 'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment, patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.'
+    - 'This patient has documentation of a hysterectomy. If hysterectomy was performed for treatment of histologic HSIL (CIN 2 or CIN 3), patients should have 3 consecutive annual HPV-based tests before entering long term surveillance. Long term surveillance involves HPV based testing at 3-year intervals for 25 years.'
     - 'Screening is generally not recommended after hysterectomy if no previous diagnosis of CIN2 or greater in the preceding 25 years and the cervix was removed at the time of hysterectomy.'
+    - 'Cancer screening is not recommended for patients who have undergone hysterectomy but have no previous diagnosis of histologic HSIL (CIN 2 or CIN 3), or completed the 25 year long term surveillance.'
   WhichPopulationMadeTheRecommendation: 2


### PR DESCRIPTION
Hysterectomy without date #66  - for special population which looks for cervix removal date, allow record of cervix removal without date. Add proposed recommendation text, test case without Hysterectomy procedure date.