### PR TITLE
Issue #74 Remove future pregnancy concerns from recommendation

### DIFF
--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -828,7 +828,7 @@ define RecommendationForHistologyResults:
   case
     // I.1 Management of Histologic HSIL, not Further Specified or Qualified
     when (
-      AgeInYears() >= 25 and
+      AgeInYears() >= 25 and AgeInYears() <= 50 and
       not RecentlyRespondedYesToFuturePregnancyConcernsQuestion and
       MostRecentBiopsyReportWasWithinPastYear and
       HistologyInterpretedAsUnspecifiedHsil
@@ -840,6 +840,21 @@ define RecommendationForHistologyResults:
         details: {
           'Treatment is preferred for histologic HSIL. Observation is acceptable if there are concerns related to future pregnancies and the following criteria are met: entire SCJ is visualized, lesion does not extend into endocervical canal, ECC is < CIN 2.',
           'Observation, if elected includes colposcopy and HPV-based testing with cotest or primary hrHPV testing at 6-month intervals for up to 2 years.'
+        }
+      }
+    // I.1 Management of Histologic HSIL, not Further Specified or Qualified over age 50
+    when (
+      AgeInYears() > 50 and
+      not RecentlyRespondedYesToFuturePregnancyConcernsQuestion and
+      MostRecentBiopsyReportWasWithinPastYear and
+      HistologyInterpretedAsUnspecifiedHsil
+    ) then
+      {
+        short: 'Surveillance or Treatment',
+        date: Today(),
+        group: 'Managing Histology (I.1)',
+        details: {
+          'Treatment is recommended for histologic HSIL.'
         }
       }
     // I.2 Management of Histologic HSIL (CIN2 or CIN3)
@@ -860,7 +875,7 @@ define RecommendationForHistologyResults:
         }
       }
     when ( // I2.2
-      AgeInYears() >= 25 and
+      AgeInYears() >= 25 and AgeInYears() <= 50 and
       not Dash.Pregnant and not RecentlyRespondedYesToFuturePregnancyConcernsQuestion and
       MostRecentBiopsyReportWasWithinPastYear and
       HistologyInterpretedAsCin2
@@ -876,6 +891,22 @@ define RecommendationForHistologyResults:
           'Observation includes colposcopy and HPV-based testing with cotest or primary hrHPV testing at 6-month intervals for up to 2 years.'
         }
       }
+    when ( // I2.2 over age 50
+      AgeInYears() > 50 and
+      not Dash.Pregnant and not RecentlyRespondedYesToFuturePregnancyConcernsQuestion and
+      MostRecentBiopsyReportWasWithinPastYear and
+      HistologyInterpretedAsCin2
+    ) then
+      {
+        short: 'Surveillance or Treatment',
+        date: Today(),
+        group: 'Managing Histology (I.2)',
+        details: {
+          'Treatment of CIN2 is recommended.',
+          'Excisional treatment is preferred, and treatment with ablation is acceptable.'
+        }
+      }
+            
     // I.3 Management of CIN2 in Those Who Are Concerned About the Potential Effect of Treatment on Future Pregnancy Outcomes
     when ( // I3.5
       AgeInYears() >= 25 and AgeInYears() <= 50 and
@@ -1188,9 +1219,24 @@ define RecommendationForHistologyResults:
           'If treatment is selected and the entire squamocolumnar junction and all lesions were fully visualized during colposcopic examination, either excision or ablation treatments are acceptable.'
         }
       }
+    // I.6 Management of AIS over 50: Adoption of Society of Gynecologic Oncology Recommendations 
+    when (
+      AgeInYears() > 50 and
+      MostRecentBiopsyReportWasWithinPastYear and
+      HistologyInterpretedAsAis
+    ) then
+      {
+        short: 'See Details',
+        date: Today(),
+        group: 'Managing Histology (I.6)',
+        details: {
+          'A diagnostic excisional procedure is recommended for all patients with a diagnosis of AIS on cervical biopsy to rule out invasive adenocarcinoma.',
+          'After the initial diagnostic procedure, hysterectomy is the preferred management for all patients who have a histologic diagnosis of AIS.'
+        }
+      }
     // I.6 Management of AIS: Adoption of Society of Gynecologic Oncology Recommendations
     when (
-      AgeInYears() >= 25 and
+      AgeInYears() >= 25 and AgeInYears() <= 50 and
       MostRecentBiopsyReportWasWithinPastYear and
       HistologyInterpretedAsAis
     ) then

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -850,7 +850,7 @@ define RecommendationForHistologyResults:
       HistologyInterpretedAsUnspecifiedHsil
     ) then
       {
-        short: 'Surveillance or Treatment',
+        short: 'Treatment',
         date: Today(),
         group: 'Managing Histology (I.1)',
         details: {
@@ -898,7 +898,7 @@ define RecommendationForHistologyResults:
       HistologyInterpretedAsCin2
     ) then
       {
-        short: 'Surveillance or Treatment',
+        short: 'Treatment',
         date: Today(),
         group: 'Managing Histology (I.2)',
         details: {

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -6146,7 +6146,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance or Treatment",
+                           "value" : "Treatment",
                            "type" : "Literal"
                         }
                      }, {
@@ -6430,7 +6430,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance or Treatment",
+                           "value" : "Treatment",
                            "type" : "Literal"
                         }
                      }, {

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -6008,22 +6008,43 @@
                         "operand" : [ {
                            "type" : "And",
                            "operand" : [ {
-                              "type" : "GreaterOrEqual",
+                              "type" : "And",
                               "operand" : [ {
-                                 "precision" : "Year",
-                                 "type" : "CalculateAge",
-                                 "operand" : {
-                                    "path" : "birthDate.value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "Patient",
-                                       "type" : "ExpressionRef"
+                                 "type" : "GreaterOrEqual",
+                                 "operand" : [ {
+                                    "precision" : "Year",
+                                    "type" : "CalculateAge",
+                                    "operand" : {
+                                       "path" : "birthDate.value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "Patient",
+                                          "type" : "ExpressionRef"
+                                       }
                                     }
-                                 }
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "25",
+                                    "type" : "Literal"
+                                 } ]
                               }, {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "25",
-                                 "type" : "Literal"
+                                 "type" : "LessOrEqual",
+                                 "operand" : [ {
+                                    "precision" : "Year",
+                                    "type" : "CalculateAge",
+                                    "operand" : {
+                                       "path" : "birthDate.value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "Patient",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "50",
+                                    "type" : "Literal"
+                                 } ]
                               } ]
                            }, {
                               "type" : "Not",
@@ -6073,6 +6094,80 @@
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "Observation, if elected includes colposcopy and HPV-based testing with cotest or primary hrHPV testing at 6-month intervals for up to 2 years.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "Greater",
+                              "operand" : [ {
+                                 "precision" : "Year",
+                                 "type" : "CalculateAge",
+                                 "operand" : {
+                                    "path" : "birthDate.value",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "Patient",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "50",
+                                 "type" : "Literal"
+                              } ]
+                           }, {
+                              "type" : "Not",
+                              "operand" : {
+                                 "name" : "RecentlyRespondedYesToFuturePregnancyConcernsQuestion",
+                                 "type" : "ExpressionRef"
+                              }
+                           } ]
+                        }, {
+                           "name" : "MostRecentBiopsyReportWasWithinPastYear",
+                           "type" : "ExpressionRef"
+                        } ]
+                     }, {
+                        "name" : "HistologyInterpretedAsUnspecifiedHsil",
+                        "type" : "ExpressionRef"
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Surveillance or Treatment",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Managing Histology (I.1)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Treatment is recommended for histologic HSIL.",
                               "type" : "Literal"
                            } ]
                         }
@@ -6171,22 +6266,43 @@
                            "operand" : [ {
                               "type" : "And",
                               "operand" : [ {
-                                 "type" : "GreaterOrEqual",
+                                 "type" : "And",
                                  "operand" : [ {
-                                    "precision" : "Year",
-                                    "type" : "CalculateAge",
-                                    "operand" : {
-                                       "path" : "birthDate.value",
-                                       "type" : "Property",
-                                       "source" : {
-                                          "name" : "Patient",
-                                          "type" : "ExpressionRef"
+                                    "type" : "GreaterOrEqual",
+                                    "operand" : [ {
+                                       "precision" : "Year",
+                                       "type" : "CalculateAge",
+                                       "operand" : {
+                                          "path" : "birthDate.value",
+                                          "type" : "Property",
+                                          "source" : {
+                                             "name" : "Patient",
+                                             "type" : "ExpressionRef"
+                                          }
                                        }
-                                    }
+                                    }, {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "25",
+                                       "type" : "Literal"
+                                    } ]
                                  }, {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "25",
-                                    "type" : "Literal"
+                                    "type" : "LessOrEqual",
+                                    "operand" : [ {
+                                       "precision" : "Year",
+                                       "type" : "CalculateAge",
+                                       "operand" : {
+                                          "path" : "birthDate.value",
+                                          "type" : "Property",
+                                          "source" : {
+                                             "name" : "Patient",
+                                             "type" : "ExpressionRef"
+                                          }
+                                       }
+                                    }, {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "50",
+                                       "type" : "Literal"
+                                    } ]
                                  } ]
                               }, {
                                  "type" : "Not",
@@ -6252,6 +6368,94 @@
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "Observation includes colposcopy and HPV-based testing with cotest or primary hrHPV testing at 6-month intervals for up to 2 years.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "type" : "Greater",
+                                 "operand" : [ {
+                                    "precision" : "Year",
+                                    "type" : "CalculateAge",
+                                    "operand" : {
+                                       "path" : "birthDate.value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "Patient",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "50",
+                                    "type" : "Literal"
+                                 } ]
+                              }, {
+                                 "type" : "Not",
+                                 "operand" : {
+                                    "name" : "Pregnant",
+                                    "libraryName" : "Dash",
+                                    "type" : "ExpressionRef"
+                                 }
+                              } ]
+                           }, {
+                              "type" : "Not",
+                              "operand" : {
+                                 "name" : "RecentlyRespondedYesToFuturePregnancyConcernsQuestion",
+                                 "type" : "ExpressionRef"
+                              }
+                           } ]
+                        }, {
+                           "name" : "MostRecentBiopsyReportWasWithinPastYear",
+                           "type" : "ExpressionRef"
+                        } ]
+                     }, {
+                        "name" : "HistologyInterpretedAsCin2",
+                        "type" : "ExpressionRef"
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Surveillance or Treatment",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Managing Histology (I.2)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Treatment of CIN2 is recommended.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Excisional treatment is preferred, and treatment with ablation is acceptable.",
                               "type" : "Literal"
                            } ]
                         }
@@ -8714,7 +8918,7 @@
                      "operand" : [ {
                         "type" : "And",
                         "operand" : [ {
-                           "type" : "GreaterOrEqual",
+                           "type" : "Greater",
                            "operand" : [ {
                               "precision" : "Year",
                               "type" : "CalculateAge",
@@ -8728,8 +8932,98 @@
                               }
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                              "value" : "25",
+                              "value" : "50",
                               "type" : "Literal"
+                           } ]
+                        }, {
+                           "name" : "MostRecentBiopsyReportWasWithinPastYear",
+                           "type" : "ExpressionRef"
+                        } ]
+                     }, {
+                        "name" : "HistologyInterpretedAsAis",
+                        "type" : "ExpressionRef"
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "See Details",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Managing Histology (I.6)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "A diagnostic excisional procedure is recommended for all patients with a diagnosis of AIS on cervical biopsy to rule out invasive adenocarcinoma.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "After the initial diagnostic procedure, hysterectomy is the preferred management for all patients who have a histologic diagnosis of AIS.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "GreaterOrEqual",
+                              "operand" : [ {
+                                 "precision" : "Year",
+                                 "type" : "CalculateAge",
+                                 "operand" : {
+                                    "path" : "birthDate.value",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "Patient",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "25",
+                                 "type" : "Literal"
+                              } ]
+                           }, {
+                              "type" : "LessOrEqual",
+                              "operand" : [ {
+                                 "precision" : "Year",
+                                 "type" : "CalculateAge",
+                                 "operand" : {
+                                    "path" : "birthDate.value",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "Patient",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "50",
+                                 "type" : "Literal"
+                              } ]
                            } ]
                         }, {
                            "name" : "MostRecentBiopsyReportWasWithinPastYear",

--- a/test/ManagementHistologyResults/cases/I1UnspecifiedHistologicHSILOver50.yml
+++ b/test/ManagementHistologyResults/cases/I1UnspecifiedHistologicHSILOver50.yml
@@ -1,0 +1,32 @@
+---
+name: I.1 Management of Histologic HSIL, not Further Specified or Qualified over age 50
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1965-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#22725004 High-grade squamous intraepithelial lesion (morphologic abnormality)
+  effectiveDateTime: 2021-05-01
+
+results:
+  Recommendation:
+    short: 'Surveillance or Treatment'
+    date: '2021-06-02'
+    group: 'Managing Histology (I.1)'
+    details: 
+      - 'Treatment is recommended for histologic HSIL.'
+  WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I1UnspecifiedHistologicHSILOver50.yml
+++ b/test/ManagementHistologyResults/cases/I1UnspecifiedHistologicHSILOver50.yml
@@ -24,7 +24,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance or Treatment'
+    short: 'Treatment'
     date: '2021-06-02'
     group: 'Managing Histology (I.1)'
     details: 

--- a/test/ManagementHistologyResults/cases/I22HistologicHSILCin2Over50.yml
+++ b/test/ManagementHistologyResults/cases/I22HistologicHSILCin2Over50.yml
@@ -1,0 +1,33 @@
+---
+name: I2.2 Management of Histologic HSIL (CIN2) over age 50
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1965-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#285838002 Cervical intraepithelial neoplasia grade 2 (disorder)
+  effectiveDateTime: 2021-05-01
+
+results:
+  Recommendation:
+    short: 'Surveillance or Treatment'
+    date: '2021-06-02'
+    group: 'Managing Histology (I.2)'
+    details: 
+    - 'Treatment of CIN2 is recommended.'
+    - 'Excisional treatment is preferred, and treatment with ablation is acceptable.'
+  WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I22HistologicHSILCin2Over50.yml
+++ b/test/ManagementHistologyResults/cases/I22HistologicHSILCin2Over50.yml
@@ -24,7 +24,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance or Treatment'
+    short: 'Treatment'
     date: '2021-06-02'
     group: 'Managing Histology (I.2)'
     details: 

--- a/test/ManagementHistologyResults/cases/I6ManagementofAISOver50.yml
+++ b/test/ManagementHistologyResults/cases/I6ManagementofAISOver50.yml
@@ -1,0 +1,33 @@
+---
+name: I6 Management of AIS over 50 Adoption of Society of Gynecologic Oncology Recommendations  
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1965-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#447760009 Endocervical adenocarcinoma in situ (disorder)
+  effectiveDateTime: 2021-05-01
+
+results:
+  Recommendation:
+    short: 'See Details'
+    date: '2021-06-02'
+    group: 'Managing Histology (I.6)'
+    details: 
+    - 'A diagnostic excisional procedure is recommended for all patients with a diagnosis of AIS on cervical biopsy to rule out invasive adenocarcinoma.'
+    - 'After the initial diagnostic procedure, hysterectomy is the preferred management for all patients who have a histologic diagnosis of AIS.'
+  WhichRarityMadeTheRecommendation: 3


### PR DESCRIPTION
Update ManageRareAbnormality I1, I2.2 and I6 to generate separate recommendation text when patient > 50 years. This removed the text regarding future pregnancy concerns and fertility sparing management options. 