### PR TITLE
2023 Errata: Managing Cytology Alone (Issue #63)

### DIFF
--- a/cql/CollateManagementData.cql
+++ b/cql/CollateManagementData.cql
@@ -166,9 +166,9 @@ define SortedCytologyReports:
   sort by date desc
 
 // Edge Cases:
-// DONE: 1. HPV but no cytology (solution: just use HPV)
-// TODO: 2. Cytology but no HPV (no solution: display error)
-// NOTE: This is being updated based on "gaps" document
+// DONE: 1. HPV but no cytology (solution: just use HPV, unless most recent result is primary HPV in which case reflex cytology testing is recommended)
+// DONE: 2. Cytology but no HPV (2023 ASCCP Guidelines Errata)
+// NOTE: This has been updated based on 2023 ASCCP Guidelines Errata
 
 define MostRecentCytologyCotest:
   Coalesce(

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -315,17 +315,8 @@ define ErrataRecommendation:
           'Immediate loop electrosurgical excision or colposcopy is recommended, except in special populations.'
         }
       }
-
-    when ( // 
-      false
-    ) then
-      {
-        short: '',
-        date: Today(),
-        details: {
-          ''
-        }
-      }
+    // The following logic phrases come directly from the JLGTD article:
+    // TODO: Implement rest of the 2023 Errata section
     else
       null
   end

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -293,8 +293,28 @@ define ErrataRecommendation:
           'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
         }
       }
-
-
+    when ( // LSIL Alone
+      AgeInYears() >= 25 and
+      CytologyAloneInterpretedAsLsil
+    ) then
+      {
+        short: 'Colposcopy',
+        date: Today(),
+        details: {
+          'Colposcopy is recommended.'
+        }
+      }
+    when ( // HSIL or SCC Alone
+      AgeInYears() >= 25 and
+      CytologyAloneInterpretedAsHsil
+    ) then
+      {
+        short: 'Colposcopy or Treatment',
+        date: Today(),
+        details: {
+          'Immediate loop electrosurgical excision or colposcopy is recommended, except in special populations.'
+        }
+      }
 
     when ( // 
       false

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -245,7 +245,69 @@ define CommonAbnormalityGroup:
     when ColposcopyResultsManagementRecommendation is not null then 'Colposcopy Results (Table 3)'
     when SurveillanceManagementRecommendation is not null then 'Surveillance (Table 2)'
     when GeneralScreeningManagementRecommendation is not null then 'General Screening (Table 1)'
+    when ErrataRecommendation is not null then '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     else 'N/A'
+  end
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+// ERRATA: 2023 Journal of Lower Genital Track Disease (JLGTD) Addendum to the 2019 ASCCP Guidelines
+
+// Per the JLGTD article, “for individuals aged 25 years or older screened with cytology alone, the 2012 guidelines should be followed.”
+// As such, the following logic is derived from the 2012 ASCCP guidelines when there is no care recommendation mentioned for the same
+// clinical scenario in the 2019 ASCCP guidelines (e.g., the 2019 guidelines expressed in this CDS already covers ‘cervical cytology alone’
+// where the result is ASC-H, and AGC or AIS not including endometrial cells, therefore it is not expressed in this section).
+
+define MostRecentHpvCotest:
+  Coalesce(
+    (Collate.SortedHpvReports) S
+      where S.date within 1 day of Collate.MostRecentCytologyReport.date
+  )
+
+define MostRecentCytologyAlone:
+  if MostRecentHpvCotest is null then
+    Collate.MostRecentCytologyReport
+  else
+    null
+
+define CytologyAloneInterpretedAsAscus:
+  MostRecentCytologyAlone.riskTableInput = 'ASC-US'
+
+define CytologyAloneInterpretedAsLsil:
+  MostRecentCytologyAlone.riskTableInput = 'LSIL'
+
+define CytologyAloneInterpretedAsHsil:
+  MostRecentCytologyAlone.riskTableInput = 'HSIL+'
+
+
+define ErrataRecommendation:
+  case
+    // Managing abnormal cervical cytology alone
+    when ( // ASC-US Alone
+      AgeInYears() >= 25 and
+      CytologyAloneInterpretedAsAscus
+    ) then
+      {
+        short: 'Reflex HPV',
+        date: Today(),
+        details: {
+          'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
+        }
+      }
+
+
+
+    when ( // 
+      false
+    ) then
+      {
+        short: '',
+        date: Today(),
+        details: {
+          ''
+        }
+      }
+    else
+      null
   end
 
 define ReflexTestingRecommendationText:
@@ -431,6 +493,10 @@ define Action:
           TreatmentRecommendationText
         }
       }
+     when (
+      ErrataRecommendation is not null
+    ) then
+      ErrataRecommendation
     else
       null
   end

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -1184,38 +1184,6 @@
                         }
                      } ]
                   }
-               }, {
-                  "when" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                     "value" : "false",
-                     "type" : "Literal"
-                  },
-                  "then" : {
-                     "type" : "Tuple",
-                     "element" : [ {
-                        "name" : "short",
-                        "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "",
-                           "type" : "Literal"
-                        }
-                     }, {
-                        "name" : "date",
-                        "value" : {
-                           "type" : "Today"
-                        }
-                     }, {
-                        "name" : "details",
-                        "value" : {
-                           "type" : "List",
-                           "element" : [ {
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "",
-                              "type" : "Literal"
-                           } ]
-                        }
-                     } ]
-                  }
                } ],
                "else" : {
                   "type" : "As",

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -836,6 +836,278 @@
                }
             }
          }, {
+            "name" : "MostRecentHpvCotest",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Coalesce",
+               "operand" : [ {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "S",
+                     "expression" : {
+                        "name" : "SortedHpvReports",
+                        "libraryName" : "Collate",
+                        "type" : "ExpressionRef"
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "where" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "In",
+                        "operand" : [ {
+                           "path" : "date",
+                           "scope" : "S",
+                           "type" : "Property"
+                        }, {
+                           "lowClosed" : true,
+                           "highClosed" : true,
+                           "type" : "Interval",
+                           "low" : {
+                              "type" : "Subtract",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentCytologyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "value" : 1,
+                                 "unit" : "day",
+                                 "type" : "Quantity"
+                              } ]
+                           },
+                           "high" : {
+                              "type" : "Add",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentCytologyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "value" : 1,
+                                 "unit" : "day",
+                                 "type" : "Quantity"
+                              } ]
+                           }
+                        } ]
+                     }, {
+                        "type" : "Not",
+                        "operand" : {
+                           "type" : "IsNull",
+                           "operand" : {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentCytologyReport",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           }
+                        }
+                     } ]
+                  }
+               } ]
+            }
+         }, {
+            "name" : "MostRecentCytologyAlone",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "If",
+               "condition" : {
+                  "type" : "IsNull",
+                  "operand" : {
+                     "name" : "MostRecentHpvCotest",
+                     "type" : "ExpressionRef"
+                  }
+               },
+               "then" : {
+                  "name" : "MostRecentCytologyReport",
+                  "libraryName" : "Collate",
+                  "type" : "ExpressionRef"
+               },
+               "else" : {
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "type" : "TupleTypeSpecifier",
+                     "element" : [ {
+                        "name" : "riskTableInput",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}String",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "allConclusions",
+                        "elementType" : {
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }
+                     }, {
+                        "name" : "date",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
+            "name" : "CytologyAloneInterpretedAsAscus",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equal",
+               "operand" : [ {
+                  "path" : "riskTableInput",
+                  "type" : "Property",
+                  "source" : {
+                     "name" : "MostRecentCytologyAlone",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "ASC-US",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "ErrataRecommendation",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Case",
+               "caseItem" : [ {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "GreaterOrEqual",
+                        "operand" : [ {
+                           "precision" : "Year",
+                           "type" : "CalculateAge",
+                           "operand" : {
+                              "path" : "birthDate.value",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "Patient",
+                                 "type" : "ExpressionRef"
+                              }
+                           }
+                        }, {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "25",
+                           "type" : "Literal"
+                        } ]
+                     }, {
+                        "name" : "CytologyAloneInterpretedAsAscus",
+                        "type" : "ExpressionRef"
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Reflex HPV",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "value" : "false",
+                     "type" : "Literal"
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               } ],
+               "else" : {
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "type" : "TupleTypeSpecifier",
+                     "element" : [ {
+                        "name" : "short",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}String",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "date",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Date",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "details",
+                        "elementType" : {
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}String",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
             "name" : "CommonAbnormalityGroup",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -921,12 +1193,66 @@
                      "value" : "General Screening (Table 1)",
                      "type" : "Literal"
                   }
+               }, {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "ErrataRecommendation",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "2023 JLGTD Addendum to the 2019 ASCCP Guidelines",
+                     "type" : "Literal"
+                  }
                } ],
                "else" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "N/A",
                   "type" : "Literal"
                }
+            }
+         }, {
+            "name" : "CytologyAloneInterpretedAsLsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equal",
+               "operand" : [ {
+                  "path" : "riskTableInput",
+                  "type" : "Property",
+                  "source" : {
+                     "name" : "MostRecentCytologyAlone",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "LSIL",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "CytologyAloneInterpretedAsHsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equal",
+               "operand" : [ {
+                  "path" : "riskTableInput",
+                  "type" : "Property",
+                  "source" : {
+                     "name" : "MostRecentCytologyAlone",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "HSIL+",
+                  "type" : "Literal"
+               } ]
             }
          }, {
             "name" : "ReflexTestingRecommendationText",
@@ -1981,6 +2307,21 @@
                            } ]
                         }
                      } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "ErrataRecommendation",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "name" : "ErrataRecommendation",
+                     "type" : "ExpressionRef"
                   }
                } ],
                "else" : {

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -985,6 +985,44 @@
                } ]
             }
          }, {
+            "name" : "CytologyAloneInterpretedAsLsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equal",
+               "operand" : [ {
+                  "path" : "riskTableInput",
+                  "type" : "Property",
+                  "source" : {
+                     "name" : "MostRecentCytologyAlone",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "LSIL",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "CytologyAloneInterpretedAsHsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equal",
+               "operand" : [ {
+                  "path" : "riskTableInput",
+                  "type" : "Property",
+                  "source" : {
+                     "name" : "MostRecentCytologyAlone",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "HSIL+",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
             "name" : "ErrataRecommendation",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -1037,6 +1075,110 @@
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "GreaterOrEqual",
+                        "operand" : [ {
+                           "precision" : "Year",
+                           "type" : "CalculateAge",
+                           "operand" : {
+                              "path" : "birthDate.value",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "Patient",
+                                 "type" : "ExpressionRef"
+                              }
+                           }
+                        }, {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "25",
+                           "type" : "Literal"
+                        } ]
+                     }, {
+                        "name" : "CytologyAloneInterpretedAsLsil",
+                        "type" : "ExpressionRef"
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Colposcopy",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Colposcopy is recommended.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "GreaterOrEqual",
+                        "operand" : [ {
+                           "precision" : "Year",
+                           "type" : "CalculateAge",
+                           "operand" : {
+                              "path" : "birthDate.value",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "Patient",
+                                 "type" : "ExpressionRef"
+                              }
+                           }
+                        }, {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "25",
+                           "type" : "Literal"
+                        } ]
+                     }, {
+                        "name" : "CytologyAloneInterpretedAsHsil",
+                        "type" : "ExpressionRef"
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Colposcopy or Treatment",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Immediate loop electrosurgical excision or colposcopy is recommended, except in special populations.",
                               "type" : "Literal"
                            } ]
                         }
@@ -1215,44 +1357,6 @@
                   "value" : "N/A",
                   "type" : "Literal"
                }
-            }
-         }, {
-            "name" : "CytologyAloneInterpretedAsLsil",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "type" : "Equal",
-               "operand" : [ {
-                  "path" : "riskTableInput",
-                  "type" : "Property",
-                  "source" : {
-                     "name" : "MostRecentCytologyAlone",
-                     "type" : "ExpressionRef"
-                  }
-               }, {
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "LSIL",
-                  "type" : "Literal"
-               } ]
-            }
-         }, {
-            "name" : "CytologyAloneInterpretedAsHsil",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "type" : "Equal",
-               "operand" : [ {
-                  "path" : "riskTableInput",
-                  "type" : "Property",
-                  "source" : {
-                     "name" : "MostRecentCytologyAlone",
-                     "type" : "ExpressionRef"
-                  }
-               }, {
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "HSIL+",
-                  "type" : "Literal"
-               } ]
             }
          }, {
             "name" : "ReflexTestingRecommendationText",

--- a/test/ManagementErrata/cases/CytologyAloneAscus.yml
+++ b/test/ManagementErrata/cases/CytologyAloneAscus.yml
@@ -1,0 +1,28 @@
+---
+name: Cytology Alone Ascus
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1991-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+  status: final
+  conclusionCode:
+  - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding) 
+  effectiveDateTime: 2021-01-01
+
+results:
+  Recommendation:
+    short: 'Reflex HPV'
+    date: '2021-06-02'
+    group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
+    details:
+    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'

--- a/test/ManagementErrata/cases/CytologyAloneHsil.yml
+++ b/test/ManagementErrata/cases/CytologyAloneHsil.yml
@@ -1,5 +1,5 @@
 ---
-name: Cytology Alone ASC-US
+name: Cytology Alone HSIL
 
 data:
 - 
@@ -16,13 +16,13 @@ data:
   code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
   status: final
   conclusionCode:
-  - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding) 
+  - SNOMEDCT#62061000119107 High grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding) 
   effectiveDateTime: 2021-01-01
 
 results:
   Recommendation:
-    short: 'Reflex HPV'
+    short: 'Colposcopy or Treatment'
     date: '2021-06-02'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
+    - 'Immediate loop electrosurgical excision or colposcopy is recommended, except in special populations.'

--- a/test/ManagementErrata/cases/CytologyAloneLsil.yml
+++ b/test/ManagementErrata/cases/CytologyAloneLsil.yml
@@ -1,5 +1,5 @@
 ---
-name: Cytology Alone ASC-US
+name: Cytology Alone LSIL
 
 data:
 - 
@@ -16,13 +16,13 @@ data:
   code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
   status: final
   conclusionCode:
-  - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding) 
+  - SNOMEDCT#62051000119105 Low grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding) 
   effectiveDateTime: 2021-01-01
 
 results:
   Recommendation:
-    short: 'Reflex HPV'
+    short: 'Colposcopy'
     date: '2021-06-02'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
+    - 'Colposcopy is recommended.'

--- a/test/ManagementErrata/cases/CytologyAloneScc.yml
+++ b/test/ManagementErrata/cases/CytologyAloneScc.yml
@@ -1,5 +1,5 @@
 ---
-name: Cytology Alone ASC-US
+name: Cytology Alone SCC
 
 data:
 - 
@@ -16,13 +16,13 @@ data:
   code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
   status: final
   conclusionCode:
-  - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding) 
+  - SNOMEDCT#1162767002 Squamous cell carcinoma (morphologic abnormality) 
   effectiveDateTime: 2021-01-01
 
 results:
   Recommendation:
-    short: 'Reflex HPV'
+    short: 'Colposcopy or Treatment'
     date: '2021-06-02'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
+    - 'Immediate loop electrosurgical excision or colposcopy is recommended, except in special populations.'

--- a/test/ManagementErrata/cqlt.yaml
+++ b/test/ManagementErrata/cqlt.yaml
@@ -1,0 +1,13 @@
+---
+library:
+  name: ManageCommonAbnormality
+  paths: ../../cql
+tests:
+  path: cases/
+options:
+  date: "2021-06-02T00:00:00.000Z"
+  vsac:
+    cache: .vscache
+  dumpFiles:
+    enabled: true
+    path: test_results


### PR DESCRIPTION
See Issue https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/issues/63. This PR implements the first part of Section 4.7.3.3.12 in the L2 (4.7.3.3.12 2023 Journal of Lower Genital Track Disease (JLGTD) Addendum to the 2019 ASCCP Guidelines) which deals with managing a cytology alone test.