### PR TITLE
Add Endocervical Curettage (ECC) procedure to procedure value set

### DIFF
--- a/fsh-tank/fsh-generated/resources/ValueSet-PertinentProcedureShortList.json
+++ b/fsh-tank/fsh-generated/resources/ValueSet-PertinentProcedureShortList.json
@@ -41,6 +41,20 @@
             ]
           },
           {
+            "code": "52889002",
+            "display": "Endocervical Curettage",
+            "designation": [
+              {
+                "use": {
+                  "code": "900000000000003001",
+                  "system": "http://snomed.info/sct",
+                  "display": "Fully specified name"
+                },
+                "value": "Endocervical curettage (procedure)"
+              }
+            ]
+          },
+          {
             "code": "120038005",
             "display": "Cervix Excision",
             "designation": [

--- a/fsh-tank/input/fsh/PertinentProcedureShortList.fsh
+++ b/fsh-tank/input/fsh/PertinentProcedureShortList.fsh
@@ -18,6 +18,10 @@ Usage: #definition
 * compose.include[=].concept[=].display = "Colposcopy"
 * compose.include[=].concept[=].designation.use = $SNOMED#900000000000003001 "Fully specified name"
 * compose.include[=].concept[=].designation.value = "Colposcopy (procedure)"
+* compose.include[=].concept[+].code = #52889002
+* compose.include[=].concept[=].display = "Endocervical Curettage"
+* compose.include[=].concept[=].designation.use = $SNOMED#900000000000003001 "Fully specified name"
+* compose.include[=].concept[=].designation.value = "Endocervical curettage (procedure)"
 * compose.include[=].concept[+].code = #120038005
 * compose.include[=].concept[=].display = "Cervix Excision"
 * compose.include[=].concept[=].designation.use = $SNOMED#900000000000003001 "Fully specified name"


### PR DESCRIPTION
Add Endocervical Curettage (ECC) procedure to PertinentProcedureShortList value set to be used by smart form mapping in ccsm-cds-service