### PR TITLE
Histologic Cancer recommendation #93

### DIFF
--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -214,6 +214,13 @@ define HistologyInterpretedAsCancer:
         aC in Dash."Histologic cancer"
   )
 
+define AnyHistologyInterpretedAsCancer:
+  AnyTrue(
+    (Collate.SortedBiopsyReports.allConclusions) aC
+      return
+        aC in Dash."Histologic cancer"
+  )
+    
 define CancerDiagnosisAfterMostRecentCytology:
   Exists(
     Dash.CervicalCancerDiagnoses C

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -1270,6 +1270,77 @@
                }
             }
          }, {
+            "name" : "AnyHistologyInterpretedAsCancer",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "AnyTrue",
+               "source" : {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "aC",
+                     "expression" : {
+                        "type" : "Flatten",
+                        "operand" : {
+                           "type" : "Query",
+                           "source" : [ {
+                              "alias" : "$this",
+                              "expression" : {
+                                 "name" : "SortedBiopsyReports",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           } ],
+                           "where" : {
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "path" : "allConclusions",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "$this",
+                                       "type" : "AliasRef"
+                                    }
+                                 }
+                              }
+                           },
+                           "return" : {
+                              "distinct" : false,
+                              "expression" : {
+                                 "path" : "allConclusions",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "$this",
+                                    "type" : "AliasRef"
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "return" : {
+                     "expression" : {
+                        "type" : "InValueSet",
+                        "code" : {
+                           "name" : "ToConcept",
+                           "libraryName" : "FHIRHelpers",
+                           "type" : "FunctionRef",
+                           "operand" : [ {
+                              "name" : "aC",
+                              "type" : "AliasRef"
+                           } ]
+                        },
+                        "valueset" : {
+                           "name" : "Histologic cancer",
+                           "libraryName" : "Dash"
+                        }
+                     }
+                  }
+               }
+            }
+         }, {
             "name" : "CancerDiagnosisAfterMostRecentCytology",
             "context" : "Patient",
             "accessLevel" : "Public",

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -61,12 +61,12 @@ context Patient
 define RecommendationForPatientsWithHistologicCancer:
   case
     when (
-      Rare.HistologyInterpretedAsCancer
+      Rare.AnyHistologyInterpretedAsCancer
     ) then
       {
         short: 'Histologic Cancer',
         date: Today(),
-        group: 'Special Population',
+        group: 'Histologic Cancer',
         details: {
           'Refer to Gynecologic Oncology.'
         }
@@ -773,6 +773,7 @@ define Recommendation:
 
 define WhichPopulationMadeTheRecommendation:
   case
+    when RecommendationForPatientsWithHistologicCancer is not null then 6
     when RecommendationForPatientsYoungerThan25 is not null then 5
     when RecommendationForPregnantPatients is not null then 4
     when RecommendationForImmunosuppressedPatients is not null then 3

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -56,6 +56,26 @@ context Patient
 //------------------------------------------------------------------------------
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+// Special Populations Management of Patients With Histologic Cancer
+
+define RecommendationForPatientsWithHistologicCancer:
+  case
+    when (
+      Rare.HistologyInterpretedAsCancer
+    ) then
+      {
+        short: 'Histologic Cancer',
+        date: Today(),
+        group: 'Special Population',
+        details: {
+          'Refer to Gynecologic Oncology.'
+        }
+      } 
+    else
+      null
+  end
+  
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 // Special Populations Section K.1 Management of Patients Younger Than 25 Years
 
 define AssociatedHpvCotest:
@@ -744,6 +764,7 @@ define RecommendationForManagingPatientsAfterHysterectomy:
 
 define Recommendation:
   Coalesce(
+    RecommendationForPatientsWithHistologicCancer,
     RecommendationForPatientsYoungerThan25,
     RecommendationForPregnantPatients,
     RecommendationForImmunosuppressedPatients,

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -152,7 +152,7 @@
                "type" : "Case",
                "caseItem" : [ {
                   "when" : {
-                     "name" : "HistologyInterpretedAsCancer",
+                     "name" : "AnyHistologyInterpretedAsCancer",
                      "libraryName" : "Rare",
                      "type" : "ExpressionRef"
                   },
@@ -174,7 +174,7 @@
                         "name" : "group",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Special Population",
+                           "value" : "Histologic Cancer",
                            "type" : "Literal"
                         }
                      }, {
@@ -4670,6 +4670,22 @@
             "expression" : {
                "type" : "Case",
                "caseItem" : [ {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "RecommendationForPatientsWithHistologicCancer",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "6",
+                     "type" : "Literal"
+                  }
+               }, {
                   "when" : {
                      "type" : "Not",
                      "operand" : {

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -145,6 +145,90 @@
                }
             }
          }, {
+            "name" : "RecommendationForPatientsWithHistologicCancer",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Case",
+               "caseItem" : [ {
+                  "when" : {
+                     "name" : "HistologyInterpretedAsCancer",
+                     "libraryName" : "Rare",
+                     "type" : "ExpressionRef"
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Histologic Cancer",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Special Population",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Refer to Gynecologic Oncology.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               } ],
+               "else" : {
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "type" : "TupleTypeSpecifier",
+                     "element" : [ {
+                        "name" : "short",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}String",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "date",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Date",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "group",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}String",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "details",
+                        "elementType" : {
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}String",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
             "name" : "Under25And2YearsAgoCytologyResults",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -4563,6 +4647,9 @@
             "expression" : {
                "type" : "Coalesce",
                "operand" : [ {
+                  "name" : "RecommendationForPatientsWithHistologicCancer",
+                  "type" : "ExpressionRef"
+               }, {
                   "name" : "RecommendationForPatientsYoungerThan25",
                   "type" : "ExpressionRef"
                }, {

--- a/test/ManagementSpecialPopulations/cases/HistologicCancer.yml
+++ b/test/ManagementSpecialPopulations/cases/HistologicCancer.yml
@@ -21,6 +21,6 @@ results:
   Recommendation: 
     short: 'Histologic Cancer'
     date: '2021-06-02'
-    group: 'Special Population'
+    group: 'Histologic Cancer'
     details:
     - 'Refer to Gynecologic Oncology.'

--- a/test/ManagementSpecialPopulations/cases/HistologicCancer.yml
+++ b/test/ManagementSpecialPopulations/cases/HistologicCancer.yml
@@ -1,0 +1,26 @@
+---
+name: Histologic Cancer
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1990-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  $iterate: *CervicalCancer
+    
+results:
+  Recommendation: 
+    short: 'Histologic Cancer'
+    date: '2021-06-02'
+    group: 'Special Population'
+    details:
+    - 'Refer to Gynecologic Oncology.'

--- a/test/ManagementSpecialPopulations/cases/HistologicCancerPriorResults.yml
+++ b/test/ManagementSpecialPopulations/cases/HistologicCancerPriorResults.yml
@@ -1,0 +1,48 @@
+---
+name: Histologic Cancer in Prior Results
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1990-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  $iterate: *CervicalCancer
+
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#285836003 Cervical intraepithelial neoplasia grade 1 (disorder)
+  effectiveDateTime: 2019-07-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#165324008 Biopsy result normal (finding) 
+  effectiveDateTime: 2021-05-21
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#165324008 Biopsy result normal (finding) 
+  effectiveDateTime: 2021-05-31
+  
+results:
+  Recommendation: 
+    short: 'Histologic Cancer'
+    date: '2021-06-02'
+    group: 'Histologic Cancer'
+    details:
+    - 'Refer to Gynecologic Oncology.'

--- a/test/ManagementSpecialPopulations/cases/resources.yml
+++ b/test/ManagementSpecialPopulations/cases/resources.yml
@@ -510,3 +510,424 @@ reusable_resources:
     status: completed
     reasonCode: SNOMEDCT#254890008 Adenocarcinoma in situ of cervix (disorder)
     performedDateTime: 2021-05-01
+- &CervicalCancer    
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#109880006 Overlapping malignant neoplasm of uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1156807006 Peripheral neuroectodermal neoplasm of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1197263001 Primary poorly differentiated endocrine carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1197268005 Primary papillary carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#123842006 Endocervical adenocarcinoma (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1259387001 Primary adenosquamous carcinoma of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1259433006 Primary carcinoma of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1259493008 Primary carcinoma of uterine cervix, invasive (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1259514003 Primary carcinoma of endocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1259516001 Primary carcinoma of exocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#184781000119102 Primary adenocarcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#188176007 Malignant neoplasm of endocervical canal (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#188177003 Malignant neoplasm of endocervical gland (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#188180002 Primary malignant neoplasm of overlapping sites of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#188183000 Malignant neoplasm of cervical stump (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#188184006 Malignant neoplasm of squamocolumnar junction of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#188469005 Metastatic malignant neoplasm to cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#208041000119100 Primary adenocarcinoma of endocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#254886006 Squamous cell carcinoma of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#254887002 Adenocarcinoma of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#254888007 Adenosquamous carcinoma of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#285432005 Carcinoma of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#314970000 Local recurrence of malignant tumor of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#363354003 Malignant tumor of cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369452007 Malignant tumor involving rectum by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369459003 Malignant tumor involving rectum by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369473007 Malignant tumor involving bladder by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369495006 Malignant tumor involving uterine corpus by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369497003 Malignant tumor involving uterine cervix by direct extension from fallopian tube (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369498008 Malignant tumor involving uterine cervix by direct extension from ovary (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369499000 Malignant tumor involving uterine cervix by direct extension from vagina (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369500009 Malignant tumor involving uterine cervix by separate metastasis from fallopian tube (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369501008 Malignant tumor involving uterine cervix by separate metastasis from ovary (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369518007 Malignant tumor involving left fallopian tube by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369527008 Malignant tumor involving left ovary by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369556008 Malignant tumor involving right fallopian tube by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369571007 Malignant tumor involving right ovary by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369574004 Malignant tumor involving uterine cervix by separate metastasis from vagina (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369577006 Malignant tumor involving uterine corpus by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369580007 Malignant tumor involving vagina by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369585002 Malignant tumor involving vagina by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369591000 Malignant tumor involving vulva by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369599003 Malignant tumor involving an organ by direct extension from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#369610009 Malignant tumor involving left fallopian tube by separate metastasis from uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#372024009 Primary malignant neoplasm of uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#372097009 Malignant neoplasm of endocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#372098004 Carcinoma of endocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#372099007 Malignant neoplasm of exocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#372100004 Carcinoma of exocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#385478001 Adenoma malignum (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#423973006 Carcinoma of uterine cervix, invasive (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#448607004 Diffuse non-Hodgkin's lymphoma of uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#448774004 Non-Hodgkin's lymphoma of uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#449059000 Follicular non-Hodgkin's lymphoma of uterine cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#722683006 Primary neuroendocrine carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#733834006 Invasive carcinoma of uterine cervix co-occurrent with human immunodeficiency virus infection (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#763063001 Adenoid basal carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#763064007 Adenoid cystic carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#763408003 Rhabdomyosarcoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#763771009 Leiomyosarcoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#764847000 Adenosarcoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#764951002 Carcinosarcoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#766248004 Primitive neuroectodermal tumor of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#766930002 Glassy cell carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#773283006 Malignant germ cell neoplasm of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#773775004 High-grade neuroendocrine carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#93779009 Primary malignant neoplasm of endocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#93789008 Primary malignant neoplasm of exocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#94279001 Metastatic malignant neoplasm to endocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#94290006 Metastatic malignant neoplasm to exocervix (disorder)
+    effectiveDateTime: 2021-05-01

--- a/test/Misc/cases/OldCancerHistology.yaml
+++ b/test/Misc/cases/OldCancerHistology.yaml
@@ -41,7 +41,7 @@ data:
   resourceType: DiagnosticReport
   code: LOINC#65753-6 
   status: final
-  conclusionCode: SNOMEDCT#363354003 
+  conclusionCode: SNOMEDCT#363354003 Malignant tumor of cervix
   effectiveDateTime: 2021-08-25
 results:
   IsIncluded: true
@@ -50,4 +50,10 @@ results:
   HasRecommendation: true
   RecommendColposcopy: false
   RecommendSurveillance: false
-  RecommendTreatment: true
+  RecommendTreatment: false
+  ManagementRecommendation: 
+    short: 'Histologic Cancer'
+    date: '2022-09-26'
+    group: 'Special Population'
+    details:
+    - 'Refer to Gynecologic Oncology.'

--- a/test/Misc/cases/OldCancerHistology.yaml
+++ b/test/Misc/cases/OldCancerHistology.yaml
@@ -54,6 +54,6 @@ results:
   ManagementRecommendation: 
     short: 'Histologic Cancer'
     date: '2022-09-26'
-    group: 'Special Population'
+    group: 'Histologic Cancer'
     details:
     - 'Refer to Gynecologic Oncology.'


### PR DESCRIPTION
Added logic to handle ANY instance of Histologic Cancer via biopsy as a special recommendation.
Added to top of ManageSpecialPopulation as this recommendation supersedes ALL others once histologic cancer biopsy is present.
This does NOT include Diagnoses of cancer, only Histologic Cancer via biopsy.
Added all cervical cancers from valueset to special population resources for test. 
OldCancerHistology now triggers this special recommendation.