### PR TITLE
Add 3 year lookback restriction to K.1 Heading 1 for CCSMCDS-44

### DIFF
--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -137,6 +137,28 @@ define Under25AndLowGradeCytologyResults:
     )
   )
 
+define Under25AndLowGradeCytologyResultsInPast3Years:
+  AgeInYears() < 25 and
+  (
+    ( 
+      Rare.CytologyInterpretedAsLsil and
+      Rare.MostRecentCytologyReport is not null and
+      Rare.MostRecentCytologyReport.date 3 years or less before Now()
+    ) or
+    (
+      Collate.MostRecentCytologyCotest is not null and
+      Collate.MostRecentCytologyCotestResult = 'ASC-US' and
+      Collate.MostRecentHpvResult = 'HPV-positive' and
+      Collate.MostRecentCytologyCotest.date 3 years or less before Now()
+    ) or
+    (
+      Rare.CytologyInterpretedAsAscus and
+      Collate.MostRecentCytologyCotestResult is null and
+      Rare.MostRecentCytologyReport is not null and
+      Rare.MostRecentCytologyReport.date 3 years or less before Now()
+    )
+  )
+
 define Under25And2YearsAgoCytologyResults:
   (Collate.SortedCytologyReports) C
     where (
@@ -444,7 +466,7 @@ define RecommendationForPatientsYoungerThan25:
         }
       }
     when ( // 1.a
-      Under25AndLowGradeCytologyResults 
+      Under25AndLowGradeCytologyResultsInPast3Years
     ) then
       {
         short: 'Cytology',

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -838,6 +838,246 @@
                } ]
             }
          }, {
+            "name" : "Under25AndLowGradeCytologyResultsInPast3Years",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "And",
+               "operand" : [ {
+                  "type" : "Less",
+                  "operand" : [ {
+                     "precision" : "Year",
+                     "type" : "CalculateAge",
+                     "operand" : {
+                        "path" : "birthDate.value",
+                        "type" : "Property",
+                        "source" : {
+                           "name" : "Patient",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "25",
+                     "type" : "Literal"
+                  } ]
+               }, {
+                  "type" : "Or",
+                  "operand" : [ {
+                     "type" : "Or",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "name" : "CytologyInterpretedAsLsil",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "name" : "MostRecentCytologyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           } ]
+                        }, {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentCytologyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "lowClosed" : true,
+                                 "highClosed" : false,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Subtract",
+                                    "operand" : [ {
+                                       "type" : "Now"
+                                    }, {
+                                       "value" : 3,
+                                       "unit" : "years",
+                                       "type" : "Quantity"
+                                    } ]
+                                 },
+                                 "high" : {
+                                    "type" : "Now"
+                                 }
+                              } ]
+                           }, {
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Now"
+                                 }
+                              }
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "type" : "Not",
+                                 "operand" : {
+                                    "type" : "IsNull",
+                                    "operand" : {
+                                       "name" : "MostRecentCytologyCotest",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              }, {
+                                 "type" : "Equal",
+                                 "operand" : [ {
+                                    "name" : "MostRecentCytologyCotestResult",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                                    "value" : "ASC-US",
+                                    "type" : "Literal"
+                                 } ]
+                              } ]
+                           }, {
+                              "type" : "Equal",
+                              "operand" : [ {
+                                 "name" : "MostRecentHpvResult",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                                 "value" : "HPV-positive",
+                                 "type" : "Literal"
+                              } ]
+                           } ]
+                        }, {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentCytologyCotest",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "lowClosed" : true,
+                                 "highClosed" : false,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Subtract",
+                                    "operand" : [ {
+                                       "type" : "Now"
+                                    }, {
+                                       "value" : 3,
+                                       "unit" : "years",
+                                       "type" : "Quantity"
+                                    } ]
+                                 },
+                                 "high" : {
+                                    "type" : "Now"
+                                 }
+                              } ]
+                           }, {
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Now"
+                                 }
+                              }
+                           } ]
+                        } ]
+                     } ]
+                  }, {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "name" : "CytologyInterpretedAsAscus",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "name" : "MostRecentCytologyCotestResult",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           } ]
+                        }, {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "name" : "MostRecentCytologyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           }
+                        } ]
+                     }, {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentCytologyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "type" : "Subtract",
+                                 "operand" : [ {
+                                    "type" : "Now"
+                                 }, {
+                                    "value" : 3,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
+                              },
+                              "high" : {
+                                 "type" : "Now"
+                              }
+                           } ]
+                        }, {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "type" : "Now"
+                              }
+                           }
+                        } ]
+                     } ]
+                  } ]
+               } ]
+            }
+         }, {
             "name" : "Under25And2YearsAgoCytologyReportInterpretedAsLsil",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -2818,7 +3058,7 @@
                   }
                }, {
                   "when" : {
-                     "name" : "Under25AndLowGradeCytologyResults",
+                     "name" : "Under25AndLowGradeCytologyResultsInPast3Years",
                      "type" : "ExpressionRef"
                   },
                   "then" : {


### PR DESCRIPTION
The change made by Sharon on Aug 15, 2023 in the L2 added the restriction that the most recent 'under 25 and low-grade cytology result' be <= 3 years ago.
I added this restriction to ONLY K.1 heading 1