### PR TITLE
Change K.1.1 part 3 lookback interval for 2 year visit to 18 months

### DIFF
--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -89,12 +89,6 @@ define Associated18MonthHpvCotest:
       where H.date within 1 day of Under25And18MonthsAgoCytologyReport.date
   )
 
-define Associated2YearHpvCotest:
-  Coalesce(
-    (Collate.SortedHpvReports) H
-      where H.date within 1 day of Under25And2YearsAgoCytologyReport.date
-  )
-
 define HistologicHsilCin2OrUnspecified:
   First(
     (Collate.SortedBiopsyReports) B
@@ -153,15 +147,8 @@ define function Under25CytologyResultsInPastInterval(LookBackStart System.Quanti
 define Under25And18MonthsAgoCytologyResults:
   Under25CytologyResultsInPastInterval(18 months, 3 years)
 
-define Under25And2YearsAgoCytologyResults:
-  Under25CytologyResultsInPastInterval(2 years, 3 years)
-  
-
 define Under25And18MonthsAgoCytologyReport:
   Under25And18MonthsAgoCytologyResults[0]
-
-define Under25And2YearsAgoCytologyReport:
-  Under25And2YearsAgoCytologyResults[0]
 
 define Under25And18MonthsAgoCytologyReportInterpretedAsLsil:
   AnyTrue(
@@ -198,11 +185,11 @@ define Under25AndSecondMostRecentLowGradeCytologyResults:
     Rare.SecondMostRecentCytologyInterpretedAsLsil or
     (
       Rare.SecondMostRecentCytologyInterpretedAsAscus and
-      Associated2YearHpvCotest.riskTableInput = 'HPV-positive'
+      Associated18MonthHpvCotest.riskTableInput = 'HPV-positive'
     ) or
     (
       Rare.SecondMostRecentCytologyInterpretedAsAscus and
-      Associated2YearHpvCotest is null
+      Associated18MonthHpvCotest is null
     )
   )
 

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -83,7 +83,13 @@ define RecommendationForPatientsWithHistologicCancer:
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 // Special Populations Section K.1 Management of Patients Younger Than 25 Years
 
-define AssociatedHpvCotest:
+define Associated18MonthHpvCotest:
+  Coalesce(
+    (Collate.SortedHpvReports) H
+      where H.date within 1 day of Under25And18MonthsAgoCytologyReport.date
+  )
+
+define Associated2YearHpvCotest:
   Coalesce(
     (Collate.SortedHpvReports) H
       where H.date within 1 day of Under25And2YearsAgoCytologyReport.date
@@ -137,40 +143,51 @@ define Under25AndLowGradeCytologyResults:
     )
   )
 
-define Under25And2YearsAgoCytologyResults:
+define function Under25CytologyResultsInPastInterval(LookBackStart System.Quantity, LookBackEnd System.Quantity):
   (Collate.SortedCytologyReports) C
+  let LookbackInterval: Interval[(Rare.MostRecentCytologyReport).date - LookBackEnd, (Rare.MostRecentCytologyReport).date - LookBackStart]
     where (
-      C.date 2 years or more before Rare.MostRecentCytologyReport.date and
-      C.date 3 years or less before Rare.MostRecentCytologyReport.date)
+      C.date in LookbackInterval
+    )
+
+define Under25And18MonthsAgoCytologyResults:
+  Under25CytologyResultsInPastInterval(18 months, 3 years)
+
+define Under25And2YearsAgoCytologyResults:
+  Under25CytologyResultsInPastInterval(2 years, 3 years)
+  
+
+define Under25And18MonthsAgoCytologyReport:
+  Under25And18MonthsAgoCytologyResults[0]
 
 define Under25And2YearsAgoCytologyReport:
   Under25And2YearsAgoCytologyResults[0]
 
-define Under25And2YearsAgoCytologyReportInterpretedAsLsil:
+define Under25And18MonthsAgoCytologyReportInterpretedAsLsil:
   AnyTrue(
-    (Under25And2YearsAgoCytologyReport.allConclusions) aC
+    (Under25And18MonthsAgoCytologyReport.allConclusions) aC
       return aC ~ "LSIL"
   )
 
-define Under25And2YearsAgoCytologyReportInterpretedAsAscus:
+define Under25And18MonthsAgoCytologyReportInterpretedAsAscus:
   AnyTrue(
-    (Under25And2YearsAgoCytologyReport.allConclusions) aC
+    (Under25And18MonthsAgoCytologyReport.allConclusions) aC
       return aC ~ "ASC-US"
   )
 
-define Under25And2YearsAgoLowGradeCytologyResults: 
+define Under25And18MonthsAgoLowGradeCytologyResults: 
   AgeInYears() < 25 and
   ( 
-    Exists(Under25And2YearsAgoCytologyResults) and
+    Exists(Under25And18MonthsAgoCytologyResults) and
     (
-      Under25And2YearsAgoCytologyReportInterpretedAsLsil or
+      Under25And18MonthsAgoCytologyReportInterpretedAsLsil or
       (
-        Under25And2YearsAgoCytologyReportInterpretedAsAscus and
-        AssociatedHpvCotest.riskTableInput = 'HPV-positive'
+        Under25And18MonthsAgoCytologyReportInterpretedAsAscus and
+        Associated18MonthHpvCotest.riskTableInput = 'HPV-positive'
       ) or
       (
-        Under25And2YearsAgoCytologyReportInterpretedAsAscus and
-        AssociatedHpvCotest is null
+        Under25And18MonthsAgoCytologyReportInterpretedAsAscus and
+        Associated18MonthHpvCotest is null
       )
     )
   )
@@ -181,11 +198,11 @@ define Under25AndSecondMostRecentLowGradeCytologyResults:
     Rare.SecondMostRecentCytologyInterpretedAsLsil or
     (
       Rare.SecondMostRecentCytologyInterpretedAsAscus and
-      AssociatedHpvCotest.riskTableInput = 'HPV-positive'
+      Associated2YearHpvCotest.riskTableInput = 'HPV-positive'
     ) or
     (
       Rare.SecondMostRecentCytologyInterpretedAsAscus and
-      AssociatedHpvCotest is null
+      Associated2YearHpvCotest is null
     )
   )
 
@@ -433,7 +450,7 @@ define RecommendationForPatientsYoungerThan25:
       }
     when ( // 1.c
       Under25AndLowGradeCytologyResults and
-      Under25And2YearsAgoLowGradeCytologyResults
+      Under25And18MonthsAgoLowGradeCytologyResults
     ) then
       {
         short: 'Colposcopy',

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -265,9 +265,10 @@
                }
             }
          }, {
-            "name" : "Under25And2YearsAgoCytologyResults",
+            "name" : "Under25CytologyResultsInPastInterval",
             "context" : "Patient",
             "accessLevel" : "Public",
+            "type" : "FunctionDef",
             "expression" : {
                "type" : "Query",
                "source" : [ {
@@ -278,16 +279,13 @@
                      "type" : "ExpressionRef"
                   }
                } ],
-               "relationship" : [ ],
-               "where" : {
-                  "type" : "And",
-                  "operand" : [ {
-                     "type" : "SameOrBefore",
-                     "operand" : [ {
-                        "path" : "date",
-                        "scope" : "C",
-                        "type" : "Property"
-                     }, {
+               "let" : [ {
+                  "identifier" : "LookbackInterval",
+                  "expression" : {
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "low" : {
                         "type" : "Subtract",
                         "operand" : [ {
                            "path" : "date",
@@ -298,22 +296,113 @@
                               "type" : "ExpressionRef"
                            }
                         }, {
-                           "value" : 2,
-                           "unit" : "years",
-                           "type" : "Quantity"
+                           "name" : "LookBackEnd",
+                           "type" : "OperandRef"
                         } ]
-                     } ]
+                     },
+                     "high" : {
+                        "type" : "Subtract",
+                        "operand" : [ {
+                           "path" : "date",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "MostRecentCytologyReport",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }
+                        }, {
+                           "name" : "LookBackStart",
+                           "type" : "OperandRef"
+                        } ]
+                     }
+                  }
+               } ],
+               "relationship" : [ ],
+               "where" : {
+                  "type" : "In",
+                  "operand" : [ {
+                     "path" : "date",
+                     "scope" : "C",
+                     "type" : "Property"
                   }, {
+                     "name" : "LookbackInterval",
+                     "type" : "QueryLetRef"
+                  } ]
+               }
+            },
+            "operand" : [ {
+               "name" : "LookBackStart",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "LookBackEnd",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "Under25And18MonthsAgoCytologyResults",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "Under25CytologyResultsInPastInterval",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "value" : 18,
+                  "unit" : "months",
+                  "type" : "Quantity"
+               }, {
+                  "value" : 3,
+                  "unit" : "years",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "Under25And18MonthsAgoCytologyReport",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Indexer",
+               "operand" : [ {
+                  "name" : "Under25And18MonthsAgoCytologyResults",
+                  "type" : "ExpressionRef"
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "Associated18MonthHpvCotest",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Coalesce",
+               "operand" : [ {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "H",
+                     "expression" : {
+                        "name" : "SortedHpvReports",
+                        "libraryName" : "Collate",
+                        "type" : "ExpressionRef"
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "where" : {
                      "type" : "And",
                      "operand" : [ {
                         "type" : "In",
                         "operand" : [ {
                            "path" : "date",
-                           "scope" : "C",
+                           "scope" : "H",
                            "type" : "Property"
                         }, {
                            "lowClosed" : true,
-                           "highClosed" : false,
+                           "highClosed" : true,
                            "type" : "Interval",
                            "low" : {
                               "type" : "Subtract",
@@ -321,24 +410,29 @@
                                  "path" : "date",
                                  "type" : "Property",
                                  "source" : {
-                                    "name" : "MostRecentCytologyReport",
-                                    "libraryName" : "Rare",
+                                    "name" : "Under25And18MonthsAgoCytologyReport",
                                     "type" : "ExpressionRef"
                                  }
                               }, {
-                                 "value" : 3,
-                                 "unit" : "years",
+                                 "value" : 1,
+                                 "unit" : "day",
                                  "type" : "Quantity"
                               } ]
                            },
                            "high" : {
-                              "path" : "date",
-                              "type" : "Property",
-                              "source" : {
-                                 "name" : "MostRecentCytologyReport",
-                                 "libraryName" : "Rare",
-                                 "type" : "ExpressionRef"
-                              }
+                              "type" : "Add",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "Under25And18MonthsAgoCytologyReport",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "value" : 1,
+                                 "unit" : "day",
+                                 "type" : "Quantity"
+                              } ]
                            }
                         } ]
                      }, {
@@ -349,15 +443,31 @@
                               "path" : "date",
                               "type" : "Property",
                               "source" : {
-                                 "name" : "MostRecentCytologyReport",
-                                 "libraryName" : "Rare",
+                                 "name" : "Under25And18MonthsAgoCytologyReport",
                                  "type" : "ExpressionRef"
                               }
                            }
                         }
                      } ]
-                  } ]
-               }
+                  }
+               } ]
+            }
+         }, {
+            "name" : "Under25And2YearsAgoCytologyResults",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "Under25CytologyResultsInPastInterval",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "value" : 2,
+                  "unit" : "years",
+                  "type" : "Quantity"
+               }, {
+                  "value" : 3,
+                  "unit" : "years",
+                  "type" : "Quantity"
+               } ]
             }
          }, {
             "name" : "Under25And2YearsAgoCytologyReport",
@@ -375,7 +485,7 @@
                } ]
             }
          }, {
-            "name" : "AssociatedHpvCotest",
+            "name" : "Associated2YearHpvCotest",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
@@ -838,7 +948,7 @@
                } ]
             }
          }, {
-            "name" : "Under25And2YearsAgoCytologyReportInterpretedAsLsil",
+            "name" : "Under25And18MonthsAgoCytologyReportInterpretedAsLsil",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
@@ -851,7 +961,7 @@
                         "path" : "allConclusions",
                         "type" : "Property",
                         "source" : {
-                           "name" : "Under25And2YearsAgoCytologyReport",
+                           "name" : "Under25And18MonthsAgoCytologyReport",
                            "type" : "ExpressionRef"
                         }
                      }
@@ -880,7 +990,7 @@
                }
             }
          }, {
-            "name" : "Under25And2YearsAgoCytologyReportInterpretedAsAscus",
+            "name" : "Under25And18MonthsAgoCytologyReportInterpretedAsAscus",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
@@ -893,7 +1003,7 @@
                         "path" : "allConclusions",
                         "type" : "Property",
                         "source" : {
-                           "name" : "Under25And2YearsAgoCytologyReport",
+                           "name" : "Under25And18MonthsAgoCytologyReport",
                            "type" : "ExpressionRef"
                         }
                      }
@@ -922,7 +1032,7 @@
                }
             }
          }, {
-            "name" : "Under25And2YearsAgoLowGradeCytologyResults",
+            "name" : "Under25And18MonthsAgoLowGradeCytologyResults",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
@@ -950,7 +1060,7 @@
                   "operand" : [ {
                      "type" : "Exists",
                      "operand" : {
-                        "name" : "Under25And2YearsAgoCytologyResults",
+                        "name" : "Under25And18MonthsAgoCytologyResults",
                         "type" : "ExpressionRef"
                      }
                   }, {
@@ -958,12 +1068,12 @@
                      "operand" : [ {
                         "type" : "Or",
                         "operand" : [ {
-                           "name" : "Under25And2YearsAgoCytologyReportInterpretedAsLsil",
+                           "name" : "Under25And18MonthsAgoCytologyReportInterpretedAsLsil",
                            "type" : "ExpressionRef"
                         }, {
                            "type" : "And",
                            "operand" : [ {
-                              "name" : "Under25And2YearsAgoCytologyReportInterpretedAsAscus",
+                              "name" : "Under25And18MonthsAgoCytologyReportInterpretedAsAscus",
                               "type" : "ExpressionRef"
                            }, {
                               "type" : "Equal",
@@ -971,7 +1081,7 @@
                                  "path" : "riskTableInput",
                                  "type" : "Property",
                                  "source" : {
-                                    "name" : "AssociatedHpvCotest",
+                                    "name" : "Associated18MonthHpvCotest",
                                     "type" : "ExpressionRef"
                                  }
                               }, {
@@ -984,12 +1094,12 @@
                      }, {
                         "type" : "And",
                         "operand" : [ {
-                           "name" : "Under25And2YearsAgoCytologyReportInterpretedAsAscus",
+                           "name" : "Under25And18MonthsAgoCytologyReportInterpretedAsAscus",
                            "type" : "ExpressionRef"
                         }, {
                            "type" : "IsNull",
                            "operand" : {
-                              "name" : "AssociatedHpvCotest",
+                              "name" : "Associated18MonthHpvCotest",
                               "type" : "ExpressionRef"
                            }
                         } ]
@@ -1041,7 +1151,7 @@
                               "path" : "riskTableInput",
                               "type" : "Property",
                               "source" : {
-                                 "name" : "AssociatedHpvCotest",
+                                 "name" : "Associated2YearHpvCotest",
                                  "type" : "ExpressionRef"
                               }
                            }, {
@@ -1060,7 +1170,7 @@
                      }, {
                         "type" : "IsNull",
                         "operand" : {
-                           "name" : "AssociatedHpvCotest",
+                           "name" : "Associated2YearHpvCotest",
                            "type" : "ExpressionRef"
                         }
                      } ]
@@ -2779,7 +2889,7 @@
                         "name" : "Under25AndLowGradeCytologyResults",
                         "type" : "ExpressionRef"
                      }, {
-                        "name" : "Under25And2YearsAgoLowGradeCytologyResults",
+                        "name" : "Under25And18MonthsAgoLowGradeCytologyResults",
                         "type" : "ExpressionRef"
                      } ]
                   },

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -453,115 +453,6 @@
                } ]
             }
          }, {
-            "name" : "Under25And2YearsAgoCytologyResults",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "name" : "Under25CytologyResultsInPastInterval",
-               "type" : "FunctionRef",
-               "operand" : [ {
-                  "value" : 2,
-                  "unit" : "years",
-                  "type" : "Quantity"
-               }, {
-                  "value" : 3,
-                  "unit" : "years",
-                  "type" : "Quantity"
-               } ]
-            }
-         }, {
-            "name" : "Under25And2YearsAgoCytologyReport",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "type" : "Indexer",
-               "operand" : [ {
-                  "name" : "Under25And2YearsAgoCytologyResults",
-                  "type" : "ExpressionRef"
-               }, {
-                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "value" : "0",
-                  "type" : "Literal"
-               } ]
-            }
-         }, {
-            "name" : "Associated2YearHpvCotest",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "type" : "Coalesce",
-               "operand" : [ {
-                  "type" : "Query",
-                  "source" : [ {
-                     "alias" : "H",
-                     "expression" : {
-                        "name" : "SortedHpvReports",
-                        "libraryName" : "Collate",
-                        "type" : "ExpressionRef"
-                     }
-                  } ],
-                  "relationship" : [ ],
-                  "where" : {
-                     "type" : "And",
-                     "operand" : [ {
-                        "type" : "In",
-                        "operand" : [ {
-                           "path" : "date",
-                           "scope" : "H",
-                           "type" : "Property"
-                        }, {
-                           "lowClosed" : true,
-                           "highClosed" : true,
-                           "type" : "Interval",
-                           "low" : {
-                              "type" : "Subtract",
-                              "operand" : [ {
-                                 "path" : "date",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "Under25And2YearsAgoCytologyReport",
-                                    "type" : "ExpressionRef"
-                                 }
-                              }, {
-                                 "value" : 1,
-                                 "unit" : "day",
-                                 "type" : "Quantity"
-                              } ]
-                           },
-                           "high" : {
-                              "type" : "Add",
-                              "operand" : [ {
-                                 "path" : "date",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "Under25And2YearsAgoCytologyReport",
-                                    "type" : "ExpressionRef"
-                                 }
-                              }, {
-                                 "value" : 1,
-                                 "unit" : "day",
-                                 "type" : "Quantity"
-                              } ]
-                           }
-                        } ]
-                     }, {
-                        "type" : "Not",
-                        "operand" : {
-                           "type" : "IsNull",
-                           "operand" : {
-                              "path" : "date",
-                              "type" : "Property",
-                              "source" : {
-                                 "name" : "Under25And2YearsAgoCytologyReport",
-                                 "type" : "ExpressionRef"
-                              }
-                           }
-                        }
-                     } ]
-                  }
-               } ]
-            }
-         }, {
             "name" : "HistologicHsilCin2OrUnspecified",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -1151,7 +1042,7 @@
                               "path" : "riskTableInput",
                               "type" : "Property",
                               "source" : {
-                                 "name" : "Associated2YearHpvCotest",
+                                 "name" : "Associated18MonthHpvCotest",
                                  "type" : "ExpressionRef"
                               }
                            }, {
@@ -1170,7 +1061,7 @@
                      }, {
                         "type" : "IsNull",
                         "operand" : {
-                           "name" : "Associated2YearHpvCotest",
+                           "name" : "Associated18MonthHpvCotest",
                            "type" : "ExpressionRef"
                         }
                      } ]

--- a/test/ManagementSpecialPopulations/cases/Young13LowGradeCytologyPersists18Month.yml
+++ b/test/ManagementSpecialPopulations/cases/Young13LowGradeCytologyPersists18Month.yml
@@ -1,0 +1,34 @@
+---
+name: Younger Than 25 Low Grade Cytology Persists at 18 Month Follow-up 1.3
+
+# Changed K.1 Heading 1c to 18 month lookback instead of 2 years
+# so this test uses resources that are within that expanded window
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1998-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  $iterate: *ASCUSOrLSIL18MonthsAgo
+- 
+  $iterate: *ASCUSOrLSILLastYear
+- 
+  $iterate: *ASCUSOrLSILThisYear
+
+results:
+  Recommendation: 
+    short: 'Colposcopy'
+    date: '2021-06-02'
+    group: 'Younger Than 25 (K.1.1)'
+    details:
+    - 'Colposcopy is recommended.'
+  WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/resources.yml
+++ b/test/ManagementSpecialPopulations/cases/resources.yml
@@ -268,6 +268,19 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding)
     effectiveDateTime: 2020-05-01
+- &ASCUSOrLSIL18MonthsAgo
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: final
+    conclusionCode:
+    - SNOMEDCT#62051000119105 Low grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding)
+    effectiveDateTime: 2019-11-01
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: final
+    conclusionCode:
+    - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding)
+    effectiveDateTime: 2019-11-01
 - &ASCUSOrLSILTwoYearsAgo
   - resourceType: DiagnosticReport
     code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain


### PR DESCRIPTION
The logic for Section K.1 (patients under 25 after abnormal screening result) heading 3 has been updated to look for most recent low grade cytology results 18 months to 3 years after initial low grade cytology result. Previously it was 2 years to 3 years. 
Note that K.1 5a and 5b have not changed their look-back interval (still >= 2 years and <=3 years), so there is additional code to handle both intervals. If the look-back for these two is updated to 18mo, then we can simplify the code. 
This fixes ccsmcds-45