### PR TITLE
K.1 heading 2 remove AGC and AIS from logic for under 25 patients

### DIFF
--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -558,6 +558,16 @@ define CytologyInterpretedAsAscH:
       return aC ~ "ASC-H"
   )
 
+define LastKnownCytologyInterpretedAsAscHInPast5Years:
+  Coalesce(
+    (Collate.SortedCytologyReports) S
+    where (S.date >= Now() - 5 years) and
+    AnyTrue(
+      (S.allConclusions) aC
+        return aC ~ "ASC-H"
+    )
+  )
+  
 define SecondMostRecentCytologyReport:
   if Count(Collate.SortedCytologyReports) > 1 then
     Collate.SortedCytologyReports[1]
@@ -1014,6 +1024,16 @@ define CytologyInterpretedAsHsil:
       return aC in "HSIL"
   )
 
+define LastKnownCytologyInterpretedAsHsilInPast5Years:
+  Coalesce(
+    (Collate.SortedCytologyReports) S
+    where (S.date >= Now() - 5 years) and
+    AnyTrue(
+      (S.allConclusions) aC
+        return aC in "HSIL"
+    )
+  )
+  
 define CervixRemovalDateIsAfterMostRecentAisBiopsy:
   (CervixRemovalDate is not null) and 
   CervixRemovalDate after Collate.MostRecentAisBiopsy.date

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -3287,6 +3287,79 @@
                }
             }
          }, {
+            "name" : "LastKnownCytologyInterpretedAsAscHInPast5Years",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Coalesce",
+               "operand" : [ {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "S",
+                     "expression" : {
+                        "name" : "SortedCytologyReports",
+                        "libraryName" : "Collate",
+                        "type" : "ExpressionRef"
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "where" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "GreaterOrEqual",
+                        "operand" : [ {
+                           "path" : "date",
+                           "scope" : "S",
+                           "type" : "Property"
+                        }, {
+                           "type" : "Subtract",
+                           "operand" : [ {
+                              "type" : "Now"
+                           }, {
+                              "value" : 5,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "AnyTrue",
+                        "source" : {
+                           "type" : "Query",
+                           "source" : [ {
+                              "alias" : "aC",
+                              "expression" : {
+                                 "path" : "allConclusions",
+                                 "scope" : "S",
+                                 "type" : "Property"
+                              }
+                           } ],
+                           "relationship" : [ ],
+                           "return" : {
+                              "expression" : {
+                                 "type" : "Equivalent",
+                                 "operand" : [ {
+                                    "name" : "ToConcept",
+                                    "libraryName" : "FHIRHelpers",
+                                    "type" : "FunctionRef",
+                                    "operand" : [ {
+                                       "name" : "aC",
+                                       "type" : "AliasRef"
+                                    } ]
+                                 }, {
+                                    "type" : "ToConcept",
+                                    "operand" : {
+                                       "name" : "ASC-H",
+                                       "type" : "CodeRef"
+                                    }
+                                 } ]
+                              }
+                           }
+                        }
+                     } ]
+                  }
+               } ]
+            }
+         }, {
             "name" : "TwoMostRecentCytologyReportsWithin5yearsApart",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -7212,6 +7285,77 @@
                      }
                   }
                }
+            }
+         }, {
+            "name" : "LastKnownCytologyInterpretedAsHsilInPast5Years",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Coalesce",
+               "operand" : [ {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "S",
+                     "expression" : {
+                        "name" : "SortedCytologyReports",
+                        "libraryName" : "Collate",
+                        "type" : "ExpressionRef"
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "where" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "GreaterOrEqual",
+                        "operand" : [ {
+                           "path" : "date",
+                           "scope" : "S",
+                           "type" : "Property"
+                        }, {
+                           "type" : "Subtract",
+                           "operand" : [ {
+                              "type" : "Now"
+                           }, {
+                              "value" : 5,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "AnyTrue",
+                        "source" : {
+                           "type" : "Query",
+                           "source" : [ {
+                              "alias" : "aC",
+                              "expression" : {
+                                 "path" : "allConclusions",
+                                 "scope" : "S",
+                                 "type" : "Property"
+                              }
+                           } ],
+                           "relationship" : [ ],
+                           "return" : {
+                              "expression" : {
+                                 "type" : "InValueSet",
+                                 "code" : {
+                                    "name" : "ToConcept",
+                                    "libraryName" : "FHIRHelpers",
+                                    "type" : "FunctionRef",
+                                    "operand" : [ {
+                                       "name" : "aC",
+                                       "type" : "AliasRef"
+                                    } ]
+                                 },
+                                 "valueset" : {
+                                    "name" : "HSIL",
+                                    "preserve" : true
+                                 }
+                              }
+                           }
+                        }
+                     } ]
+                  }
+               } ]
             }
          }, {
             "name" : "CervixRemovalDateIsAfterMostRecentAisBiopsy",

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -374,12 +374,9 @@ define RecommendationForPatientsYoungerThan25:
     // Heading 1 & Heading 2: Initial Management After an Abnormal Screening Test Result; Management of Cytology ASC-H and HSIL in Patients Younger than 25 Years
     when ( // 2
       AgeInYears() < 25 and
-      Rare.MostRecentCytologyReportWasWithinPastFiveYears and
       (
-        Rare.CytologyInterpretedAsHsil or
-        Rare.CytologyInterpretedAsAscH or
-        Rare.CytologyInterpretedAsAgc or
-        Rare.CytologyInterpretedAsAis
+        Rare.LastKnownCytologyInterpretedAsHsilInPast5Years is not null or
+        Rare.LastKnownCytologyInterpretedAsAscHInPast5Years is not null
       ) and
       not BiopsySinceMostRecentCytology
     ) then

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -2424,54 +2424,45 @@
                      "operand" : [ {
                         "type" : "And",
                         "operand" : [ {
-                           "type" : "And",
+                           "type" : "Less",
                            "operand" : [ {
-                              "type" : "Less",
-                              "operand" : [ {
-                                 "precision" : "Year",
-                                 "type" : "CalculateAge",
-                                 "operand" : {
-                                    "path" : "birthDate.value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "Patient",
-                                       "type" : "ExpressionRef"
-                                    }
+                              "precision" : "Year",
+                              "type" : "CalculateAge",
+                              "operand" : {
+                                 "path" : "birthDate.value",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "Patient",
+                                    "type" : "ExpressionRef"
                                  }
-                              }, {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "25",
-                                 "type" : "Literal"
-                              } ]
+                              }
                            }, {
-                              "name" : "MostRecentCytologyReportWasWithinPastFiveYears",
-                              "libraryName" : "Rare",
-                              "type" : "ExpressionRef"
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "value" : "25",
+                              "type" : "Literal"
                            } ]
                         }, {
                            "type" : "Or",
                            "operand" : [ {
-                              "type" : "Or",
-                              "operand" : [ {
-                                 "type" : "Or",
-                                 "operand" : [ {
-                                    "name" : "CytologyInterpretedAsHsil",
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "name" : "LastKnownCytologyInterpretedAsHsilInPast5Years",
                                     "libraryName" : "Rare",
                                     "type" : "ExpressionRef"
-                                 }, {
-                                    "name" : "CytologyInterpretedAsAscH",
-                                    "libraryName" : "Rare",
-                                    "type" : "ExpressionRef"
-                                 } ]
-                              }, {
-                                 "name" : "CytologyInterpretedAsAgc",
-                                 "libraryName" : "Rare",
-                                 "type" : "ExpressionRef"
-                              } ]
+                                 }
+                              }
                            }, {
-                              "name" : "CytologyInterpretedAsAis",
-                              "libraryName" : "Rare",
-                              "type" : "ExpressionRef"
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "name" : "LastKnownCytologyInterpretedAsAscHInPast5Years",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
                            } ]
                         } ]
                      }, {

--- a/test/ManagementRareCytology/cases/G11AGCAISCytologyUnder25.yml
+++ b/test/ManagementRareCytology/cases/G11AGCAISCytologyUnder25.yml
@@ -1,0 +1,32 @@
+---
+name: G1.2 Cytology Interpreted as AGC or AIS Without Atypical Endometrial Cells in Patient Under 25
+
+# Section K.1 heading 2 removed AGC and AIS from logic for patients under 25 with high-grade cytology.
+# These patients are covered by G.1
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1997-04-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  $iterate: *AgcOrAisWithinPast5Years
+
+results:
+  Recommendation:
+    short: 'See Details'
+    date: '2021-06-02'
+    group: 'Rare Cytology (G.1.1)'
+    details:
+    - 'Colposcopy is recommended.'
+    - 'Endocervical sampling is recommended at initial colposcopy, except in pregnancy.'
+    - 'Endometrial sampling is also recommended for nonpregnant patients younger than 35 years at increased risk of endometrial neoplasia based on clinical indications (e.g., abnormal uterine bleeding, conditions suggesting chronic anovulation, or obesity).'
+  WhichRarityMadeTheRecommendation: 1  

--- a/test/ManagementRareCytology/cases/G11AGCAISCytologyUnder25.yml
+++ b/test/ManagementRareCytology/cases/G11AGCAISCytologyUnder25.yml
@@ -1,5 +1,5 @@
 ---
-name: G1.2 Cytology Interpreted as AGC or AIS Without Atypical Endometrial Cells in Patient Under 25
+name: G1.1 Cytology Interpreted as AGC or AIS Without Atypical Endometrial Cells in Patient Under 25
 
 # Section K.1 heading 2 removed AGC and AIS from logic for patients under 25 with high-grade cytology.
 # These patients are covered by G.1

--- a/test/ManagementSpecialPopulations/cases/resources.yml
+++ b/test/ManagementSpecialPopulations/cases/resources.yml
@@ -230,18 +230,6 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#441088002 Atypical squamous cells on cervical Papanicolaou smear cannot exclude high grade squamous intraepithelial lesion (finding)
     effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
-    status: final
-    conclusionCode:
-    - SNOMEDCT#441219009 Atypical glandular cells on cervical Papanicolaou smear (finding) 
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
-    status: final
-    conclusionCode:
-    - SNOMEDCT#254890008 Adenocarcinoma in situ of cervix (disorder)
-    effectiveDateTime: 2021-05-01
 - &ASCUSOrLSILThisYear
   - resourceType: DiagnosticReport
     code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain


### PR DESCRIPTION
This updates Section K.1 heading 2.
Remove the check for AGC and AIS from high-grade cytology for patients under 25. Remove the requirement the result be the most recent cytology - any ASC-H or HSIL in the past 5 years is sufficient to trigger this in patients under 25.

This fixes ccsmcds-90. 