### PR TITLE
Update lookback intervals for I.3.3 and K.1.4 part 5

### DIFF
--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -1247,7 +1247,7 @@ define RecommendationForHistologyResults:
       (InitialCervicalHistologyInterpretedAsUnspecifiedHsilOrCin2InLast18Months is not null) and
       MostRecentNegativeHsilSurveillanceResultWithin18Months
       SecondMostRecentNegativeHsilSurveillanceResultWithin18Months and
-      Collate.MostRecentBiopsyReport.date 6 months or more after SecondMostRecentBiopsyReport.date
+      Collate.MostRecentBiopsyReport.date 3 months or more after SecondMostRecentBiopsyReport.date
       // TODO: Investigate whether RecentlyRespondedYesToFuturePregnancyConcernsQuestion needs to be checked for I3.3, 13.4, and I3.5
     ) then
       {

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -9207,7 +9207,7 @@
                                  "type" : "ExpressionRef"
                               }
                            }, {
-                              "value" : 6,
+                              "value" : 3,
                               "unit" : "months",
                               "type" : "Quantity"
                            } ]

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -301,7 +301,7 @@ define RecommendationForPatientsYoungerThan25:
         Rare.SecondMostRecentHistologyInterpretedAsCin2 or
         Rare.SecondMostRecentHistologyInterpretedAsUnspecifiedHsil
       ) and
-      Rare.SecondMostRecentBiopsyReport.date 2 years or more before Collate.MostRecentBiopsyReport.date and
+      Rare.SecondMostRecentBiopsyReport.date 18 months or more before Collate.MostRecentBiopsyReport.date and
       Rare.SecondMostRecentBiopsyReport.date less than 3 years before Collate.MostRecentBiopsyReport.date
     ) then
       {

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -1970,8 +1970,8 @@
                                     "type" : "ExpressionRef"
                                  }
                               }, {
-                                 "value" : 2,
-                                 "unit" : "years",
+                                 "value" : 18,
+                                 "unit" : "months",
                                  "type" : "Quantity"
                               } ]
                            } ]


### PR DESCRIPTION
Adjust the lookback intervals for I.3.3 from >=6mo to >=3mo, and for K.1.4 from >=2 years to >=18 months.
I.4.4 and I.4.5 were already updated in PR120.
K.1 3 and 5a were addressed in PR123.
This does not address loopback periods for common abnormalities as mentioned in ccsmcds-72.


