### PR TITLE
Update Observation Logic Section K.1 Heading 3

### DIFF
--- a/cql/CollateManagementData.cql
+++ b/cql/CollateManagementData.cql
@@ -438,8 +438,14 @@ define AisBiopsies:
   SortedBiopsyReports S
     where S.riskTableInput in {'AIS'}
 
+// I believe this is mis-named - it does not refer to the Most Recent Biopsy being AIS
+// but instead finds the chronologically newest of all AIS biopsies
+// This is what should be called LastKnownAisBiopsy
 define MostRecentAisBiopsy:
   First(AisBiopsies)
+  
+define LastKnownAisBiopsy:
+  First(AisBiopsies) 
   
 // Look for treatments after this CIN2/CIN3 biopsy
 define CervicalPrecancerTreatments:

--- a/cql/CollateManagementData.json
+++ b/cql/CollateManagementData.json
@@ -3073,6 +3073,17 @@
                }
             }
          }, {
+            "name" : "LastKnownAisBiopsy",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "First",
+               "source" : {
+                  "name" : "AisBiopsies",
+                  "type" : "ExpressionRef"
+               }
+            }
+         }, {
             "name" : "MostRecentHpvResultAfterTreatment",
             "context" : "Patient",
             "accessLevel" : "Public",

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -1024,6 +1024,10 @@ define CytologyInterpretedAsHsil:
       return aC in "HSIL"
   )
 
+define CytologyInterpretedAsAscHOrHsil:
+  CytologyInterpretedAsAscH or
+  CytologyInterpretedAsHsil
+  
 define LastKnownCytologyInterpretedAsHsilInPast5Years:
   Coalesce(
     (Collate.SortedCytologyReports) S

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -7287,6 +7287,20 @@
                }
             }
          }, {
+            "name" : "CytologyInterpretedAsAscHOrHsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Or",
+               "operand" : [ {
+                  "name" : "CytologyInterpretedAsAscH",
+                  "type" : "ExpressionRef"
+               }, {
+                  "name" : "CytologyInterpretedAsHsil",
+                  "type" : "ExpressionRef"
+               } ]
+            }
+         }, {
             "name" : "LastKnownCytologyInterpretedAsHsilInPast5Years",
             "context" : "Patient",
             "accessLevel" : "Public",

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -244,8 +244,15 @@ define RecommendationForPatientsYoungerThan25:
         Rare.CytologyInterpretedAsHsil or
         Rare.CytologyInterpretedAsAscH
       ) and
-      Rare.MostRecentCytologyReport.date more than 18 months after Collate.MostRecentBiopsyReport.date and
-      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      Rare.MostRecentCytologyReport.date more than 2 years after Collate.MostRecentBiopsyReport.date and
+      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date and
+      not (
+      // cannot find these in the 2-3 year window after the Histology interpreted as Cin1OrNormal
+      // NOT histologic HSIL (CIN2)
+      // NOT Histologic HSIL, Unspecified
+      // NOT Histologic AIS
+      // NOT Histologic Cancer
+      )
     ) then
       {
         short: 'See Details',

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -217,10 +217,20 @@ define HistologyInterpretedAsLessThanCin2AfterAbnormalCytologyScreening:
   Collate.MostRecentBiopsyReport.date 3 years or less after Rare.MostRecentCytologyReport.date
 
 define SecondMostRecentCytologyInterpretedAsAscHOrHsil:
+  SecondMostRecentCytologyInterpretedAsAscH or
+  SecondMostRecentCytologyInterpretedAsHsil
+
+define SecondMostRecentCytologyInterpretedAsAscH:
   AnyTrue(
     (Rare.SecondMostRecentCytologyReport.allConclusions) aC
       return
-        aC ~ "ASC-H" or
+        aC ~ "ASC-H"
+  )
+
+define SecondMostRecentCytologyInterpretedAsHsil:
+  AnyTrue(
+    (Rare.SecondMostRecentCytologyReport.allConclusions) aC
+      return
         aC in "HSIL"
   )
 
@@ -245,14 +255,14 @@ define RecommendationForPatientsYoungerThan25:
         Rare.CytologyInterpretedAsAscH
       ) and
       Rare.MostRecentCytologyReport.date more than 2 years after Collate.MostRecentBiopsyReport.date and
-      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date and
-      not (
+      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      // and    not (
       // cannot find these in the 2-3 year window after the Histology interpreted as Cin1OrNormal
       // NOT histologic HSIL (CIN2)
       // NOT Histologic HSIL, Unspecified
       // NOT Histologic AIS
       // NOT Histologic Cancer
-      )
+//      )
     ) then
       {
         short: 'See Details',
@@ -263,8 +273,9 @@ define RecommendationForPatientsYoungerThan25:
           'A diagnostic excisional procedure is recommended in patients when the squamocolumnar junction or the upper limit of all lesions are not fully visualized.'
         }
       }    
+
     when ( // Heading 3.2
-      AgeInYears() >= 21 and AgeInYears() < 25 and
+      AgeInYears() >= 21 and AgeInYears() < 25 and 
       Rare.HistologyInterpretedAsCin1OrNormal and
       (
         Collate.CytologyInterpretedAsAscusOrAbove or
@@ -282,11 +293,17 @@ define RecommendationForPatientsYoungerThan25:
           'Colposcopy is recommended.'
         }
       }    
-    when ( // Heading 3.1b
+
+// ===========    
+// K.1 Heading 3 Heading Part 1
+
+    when ( // Heading K.1.3.1 case a
       AgeInYears() < 25 and
       Rare.HistologyInterpretedAsCin1OrNormal and
-      Rare.CytologyInterpretedAsHsil and
-      Rare.MostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date
+      Rare.CytologyInterpretedAsHsil
+      // How far back can the CIN1 Histology report be?
+      // Rare.MostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date
+      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
     ) then
       {
         short: 'Colposcopy and Cytology',
@@ -298,11 +315,99 @@ define RecommendationForPatientsYoungerThan25:
           '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
         }
       }
-    when ( // Heading 3.1c
+
+    when ( // Heading K.1.3.1 case b
+      AgeInYears() < 25 and
+      Rare.CytologyInterpretedAsNilm and  // we don't have a < NILM
+      Rare.HistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsHsil and
+      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      
+      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
+    ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
+    when ( // Heading K.1.3.1 case c
+      // 1 biopsy after CIN1 preceded by HSIL
+      AgeInYears() < 25 and
+      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
+      Rare.CytologyInterpretedAsHsil and
+      Rare.HistologyInterpretedAsCin1OrNormal  and
+      Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
+      
+      // Rare.MostRecentCytologyReport.date less than 12 months before Rare.SecondMostRecentBiopsyReport.date
+      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
+    ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
+    when ( // Heading K.1.3.1 case d
+      // 1 cyto, 1 biopsy after CIN1 preceded by HSIL
+      AgeInYears() < 25 and
+      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsHsil and
+      Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date and
+      Rare.MostRecentCytologyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
+      
+      
+      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
+    ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
+// ============
+// K.1 Heading 3 Part 2(a)
+
+    when ( // Heading K1.3.2(a) case 1
       AgeInYears() < 25 and
       Rare.HistologyInterpretedAsCin1OrNormal and
-      Rare.CytologyInterpretedAsAscH and
-      Rare.MostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date
+      Rare.CytologyInterpretedAsAscH
+      // Is there a lookback range to the Cin1OrNormal Histology?
+      // Is there a lookback range between the Cin1OrNormal and the ASC-H ?
+    ) then
+      {
+        short: 'Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+      
+    when ( // Heading K1.3.2(a) case 2
+      AgeInYears() < 25 and
+      Rare.HistologyInterpretedAsCin1OrNormal and
+      // Rare.CytologyInterpretedAsAscH and
+      SecondMostRecentCytologyInterpretedAsAscH and
+      Rare.CytologyInterpretedAsNilm and
+      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
     ) then
       {
         short: 'Cytology',
@@ -315,6 +420,30 @@ define RecommendationForPatientsYoungerThan25:
         }
       }
 
+// ============
+// K.1 Heading 3 Part 2(b)
+
+    when ( // Heading K1.3.2(b)
+      AgeInYears() < 25 and
+      Rare.HistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsAscHOrHsil and 
+      (
+        CytologyInterpretedAsAscusOrAbove or
+        Rare.CytologyInterpretedAsAis
+      ) and
+      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      // Is there a lookback range to the Cin1OrNormal Histology?
+      // Is there a lookback range between the Cin1OrNormal and the ASC-H/HSIL?
+    ) then
+      {
+        short: 'Colposcopy',
+        date: Today(),
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Colposcopy is recommended.'
+        }
+      }
+      
     // Heading 4: Management of Histologic HSIL (CIN2 or CIN3) for Patients Younger Than 25 Years
     when ( // Heading4.5
       AgeInYears() < 25 and

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -246,23 +246,18 @@ define ShouldSwitchToRiskAt25Text:
 define RecommendationForPatientsYoungerThan25:
   case
     // Heading 3: Management of Histology of Less than CIN2 Preceded by Cytology ASC-H and HSIL in Patients Younger than 25 Year
-    when ( // Heading 3.3
+    // ===========    
+    when ( // K.1 Heading 3 case 1
       AgeInYears() < 25 and
       not Dash.Pregnant and
       Rare.HistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsAscHOrHsil and
+      Rare.SecondMostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date and
       (
-        Rare.CytologyInterpretedAsHsil or
-        Rare.CytologyInterpretedAsAscH
-      ) and
-      Rare.MostRecentCytologyReport.date more than 2 years after Collate.MostRecentBiopsyReport.date and
-      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
-      // and    not (
-      // cannot find these in the 2-3 year window after the Histology interpreted as Cin1OrNormal
-      // NOT histologic HSIL (CIN2)
-      // NOT Histologic HSIL, Unspecified
-      // NOT Histologic AIS
-      // NOT Histologic Cancer
-//      )
+        Rare.CytologyInterpretedAsAscHOrHsil and
+        Rare.MostRecentCytologyReport.date more than 2 years after Collate.MostRecentBiopsyReport.date and
+        Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      )
     ) then
       {
         short: 'See Details',
@@ -274,111 +269,32 @@ define RecommendationForPatientsYoungerThan25:
         }
       }    
 
-    when ( // Heading 3.2
-      AgeInYears() >= 21 and AgeInYears() < 25 and 
-      Rare.HistologyInterpretedAsCin1OrNormal and
+    when ( // K.1 Heading 3 case 2
+      AgeInYears() < 25 and
+      not Dash.Pregnant and
+      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsAscHOrHsil and 
+      Rare.SecondMostRecentCytologyReport.date less than 12 months before Rare.SecondMostRecentBiopsyReport.date and
       (
-        Collate.CytologyInterpretedAsAscusOrAbove or
-        Rare.CytologyInterpretedAsAis
+        Rare.CytologyInterpretedAsAscHOrHsil and
+        Rare.MostRecentCytologyReport.date more than 2 years after Rare.SecondMostRecentBiopsyReport.date and
+        Rare.MostRecentCytologyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
       ) and
-      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date and
-      SecondMostRecentCytologyInterpretedAsAscHOrHsil and
-      Rare.SecondMostRecentCytologyReport.date less than 6 months before Collate.MostRecentBiopsyReport.date
+      (
+        Rare.HistologyInterpretedAsCin1OrNormal and
+        Collate.MostRecentBiopsyReport.date more than 2 years after Rare.SecondMostRecentBiopsyReport.date and
+        Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
+      )
     ) then
       {
-        short: 'Colposcopy',
+        short: 'See Details',
         date: Today(),
         group: 'Younger Than 25 (K.1.3)',
         details: {
-          'Colposcopy is recommended.'
+          'A diagnostic excisional procedure is recommended for patients under 25 years, unless the patient is pregnant.',
+          'A diagnostic excisional procedure is recommended in patients when the squamocolumnar junction or the upper limit of all lesions are not fully visualized.'
         }
-      }    
-
-// ===========    
-// K.1 Heading 3 Heading Part 1
-
-    when ( // Heading K.1.3.1 case a
-      AgeInYears() < 25 and
-      Rare.HistologyInterpretedAsCin1OrNormal and
-      Rare.CytologyInterpretedAsHsil
-      // How far back can the CIN1 Histology report be?
-      // Rare.MostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date
-      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
-    ) then
-      {
-        short: 'Colposcopy and Cytology',
-        date: Collate.DateOfMostRecentReport + 1 year,
-        group: 'Younger Than 25 (K.1.3)',
-        details: {
-          'Observation is recommended with colposcopy and cytology in 1 year.',
-          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
-          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
-        }
-      }
-
-    when ( // Heading K.1.3.1 case b
-      AgeInYears() < 25 and
-      Rare.CytologyInterpretedAsNilm and  // we don't have a < NILM
-      Rare.HistologyInterpretedAsCin1OrNormal and
-      SecondMostRecentCytologyInterpretedAsHsil and
-      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
-      
-      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
-    ) then
-      {
-        short: 'Colposcopy and Cytology',
-        date: Collate.DateOfMostRecentReport + 1 year,
-        group: 'Younger Than 25 (K.1.3)',
-        details: {
-          'Observation is recommended with colposcopy and cytology in 1 year.',
-          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
-          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
-        }
-      }
-
-    when ( // Heading K.1.3.1 case c
-      // 1 biopsy after CIN1 preceded by HSIL
-      AgeInYears() < 25 and
-      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
-      Rare.CytologyInterpretedAsHsil and
-      Rare.HistologyInterpretedAsCin1OrNormal  and
-      Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
-      
-      // Rare.MostRecentCytologyReport.date less than 12 months before Rare.SecondMostRecentBiopsyReport.date
-      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
-    ) then
-      {
-        short: 'Colposcopy and Cytology',
-        date: Collate.DateOfMostRecentReport + 1 year,
-        group: 'Younger Than 25 (K.1.3)',
-        details: {
-          'Observation is recommended with colposcopy and cytology in 1 year.',
-          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
-          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
-        }
-      }
-
-    when ( // Heading K.1.3.1 case d
-      // 1 cyto, 1 biopsy after CIN1 preceded by HSIL
-      AgeInYears() < 25 and
-      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
-      SecondMostRecentCytologyInterpretedAsHsil and
-      Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date and
-      Rare.MostRecentCytologyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
-      
-      
-      // DO WE HAVE A DATE RANGE FOR THIS HSIL BEFORE THE CIN1?
-    ) then
-      {
-        short: 'Colposcopy and Cytology',
-        date: Collate.DateOfMostRecentReport + 1 year,
-        group: 'Younger Than 25 (K.1.3)',
-        details: {
-          'Observation is recommended with colposcopy and cytology in 1 year.',
-          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
-          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
-        }
-      }
+      }   
 
 // ============
 // K.1 Heading 3 Part 2(a)
@@ -386,9 +302,8 @@ define RecommendationForPatientsYoungerThan25:
     when ( // Heading K1.3.2(a) case 1
       AgeInYears() < 25 and
       Rare.HistologyInterpretedAsCin1OrNormal and
-      Rare.CytologyInterpretedAsAscH
-      // Is there a lookback range to the Cin1OrNormal Histology?
-      // Is there a lookback range between the Cin1OrNormal and the ASC-H ?
+      Rare.CytologyInterpretedAsAscH and
+      Rare.MostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date
     ) then
       {
         short: 'Cytology',
@@ -400,14 +315,16 @@ define RecommendationForPatientsYoungerThan25:
           '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
         }
       }
-      
+
     when ( // Heading K1.3.2(a) case 2
       AgeInYears() < 25 and
       Rare.HistologyInterpretedAsCin1OrNormal and
-      // Rare.CytologyInterpretedAsAscH and
       SecondMostRecentCytologyInterpretedAsAscH and
-      Rare.CytologyInterpretedAsNilm and
-      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      Rare.SecondMostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date and
+      (
+        Rare.CytologyInterpretedAsNilm and
+        Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+      )
     ) then
       {
         short: 'Cytology',
@@ -427,13 +344,12 @@ define RecommendationForPatientsYoungerThan25:
       AgeInYears() < 25 and
       Rare.HistologyInterpretedAsCin1OrNormal and
       SecondMostRecentCytologyInterpretedAsAscHOrHsil and 
+      Rare.SecondMostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date and
       (
-        CytologyInterpretedAsAscusOrAbove or
+        Collate.CytologyInterpretedAsAscusOrAbove or
         Rare.CytologyInterpretedAsAis
       ) and
       Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
-      // Is there a lookback range to the Cin1OrNormal Histology?
-      // Is there a lookback range between the Cin1OrNormal and the ASC-H/HSIL?
     ) then
       {
         short: 'Colposcopy',
@@ -443,7 +359,86 @@ define RecommendationForPatientsYoungerThan25:
           'Colposcopy is recommended.'
         }
       }
-      
+
+// ===========    
+// K.1 Heading 3 Heading Part 1
+
+    when ( // Heading K.1.3.1 case a
+      AgeInYears() < 25 and
+      Rare.HistologyInterpretedAsCin1OrNormal and
+      Rare.CytologyInterpretedAsHsil and
+      Rare.MostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date
+    ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
+    when ( // Heading K.1.3.1 case b
+      AgeInYears() < 25 and
+      Rare.CytologyInterpretedAsNilm and  
+      Rare.HistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsHsil and
+      Rare.SecondMostRecentCytologyReport.date less than 12 months before Collate.MostRecentBiopsyReport.date and
+      Rare.MostRecentCytologyReport.date less than 3 years after Collate.MostRecentBiopsyReport.date
+    ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
+    when ( // Heading K.1.3.1 case c
+      // 1 biopsy after CIN1 preceded by HSIL
+      AgeInYears() < 25 and
+      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
+      Rare.CytologyInterpretedAsHsil and
+      Rare.MostRecentCytologyReport.date less than 12 months before Rare.SecondMostRecentBiopsyReport.date and
+      Rare.HistologyInterpretedAsCin1OrNormal  and
+      Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
+          ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
+    when ( // Heading K.1.3.1 case d
+      // 1 cyto and 1 biopsy after CIN1 preceded by HSIL
+      AgeInYears() < 25 and
+      Rare.SecondMostRecentHistologyInterpretedAsCin1OrNormal and
+      SecondMostRecentCytologyInterpretedAsHsil and
+      Rare.SecondMostRecentCytologyReport.date less than 12 months before Rare.SecondMostRecentBiopsyReport.date and
+      Collate.MostRecentBiopsyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date and
+      Rare.MostRecentCytologyReport.date less than 3 years after Rare.SecondMostRecentBiopsyReport.date
+    ) then
+      {
+        short: 'Colposcopy and Cytology',
+        date: Collate.DateOfMostRecentReport + 1 year,
+        group: 'Younger Than 25 (K.1.3)',
+        details: {
+          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
+          '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
+        }
+      }
+
     // Heading 4: Management of Histologic HSIL (CIN2 or CIN3) for Patients Younger Than 25 Years
     when ( // Heading4.5
       AgeInYears() < 25 and

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -1354,7 +1354,7 @@
                } ]
             }
          }, {
-            "name" : "SecondMostRecentCytologyInterpretedAsAscHOrHsil",
+            "name" : "SecondMostRecentCytologyInterpretedAsAscH",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
@@ -1376,43 +1376,80 @@
                   "relationship" : [ ],
                   "return" : {
                      "expression" : {
-                        "type" : "Or",
+                        "type" : "Equivalent",
                         "operand" : [ {
-                           "type" : "Equivalent",
+                           "name" : "ToConcept",
+                           "libraryName" : "FHIRHelpers",
+                           "type" : "FunctionRef",
                            "operand" : [ {
-                              "name" : "ToConcept",
-                              "libraryName" : "FHIRHelpers",
-                              "type" : "FunctionRef",
-                              "operand" : [ {
-                                 "name" : "aC",
-                                 "type" : "AliasRef"
-                              } ]
-                           }, {
-                              "type" : "ToConcept",
-                              "operand" : {
-                                 "name" : "ASC-H",
-                                 "type" : "CodeRef"
-                              }
+                              "name" : "aC",
+                              "type" : "AliasRef"
                            } ]
                         }, {
-                           "type" : "InValueSet",
-                           "code" : {
-                              "name" : "ToConcept",
-                              "libraryName" : "FHIRHelpers",
-                              "type" : "FunctionRef",
-                              "operand" : [ {
-                                 "name" : "aC",
-                                 "type" : "AliasRef"
-                              } ]
-                           },
-                           "valueset" : {
-                              "name" : "HSIL",
-                              "preserve" : true
+                           "type" : "ToConcept",
+                           "operand" : {
+                              "name" : "ASC-H",
+                              "type" : "CodeRef"
                            }
                         } ]
                      }
                   }
                }
+            }
+         }, {
+            "name" : "SecondMostRecentCytologyInterpretedAsHsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "AnyTrue",
+               "source" : {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "aC",
+                     "expression" : {
+                        "path" : "allConclusions",
+                        "type" : "Property",
+                        "source" : {
+                           "name" : "SecondMostRecentCytologyReport",
+                           "libraryName" : "Rare",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "return" : {
+                     "expression" : {
+                        "type" : "InValueSet",
+                        "code" : {
+                           "name" : "ToConcept",
+                           "libraryName" : "FHIRHelpers",
+                           "type" : "FunctionRef",
+                           "operand" : [ {
+                              "name" : "aC",
+                              "type" : "AliasRef"
+                           } ]
+                        },
+                        "valueset" : {
+                           "name" : "HSIL",
+                           "preserve" : true
+                        }
+                     }
+                  }
+               }
+            }
+         }, {
+            "name" : "SecondMostRecentCytologyInterpretedAsAscHOrHsil",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Or",
+               "operand" : [ {
+                  "name" : "SecondMostRecentCytologyInterpretedAsAscH",
+                  "type" : "ExpressionRef"
+               }, {
+                  "name" : "SecondMostRecentCytologyInterpretedAsHsil",
+                  "type" : "ExpressionRef"
+               } ]
             }
          }, {
             "name" : "BiopsySinceMostRecentCytology",
@@ -1507,19 +1544,87 @@
                                  "type" : "ExpressionRef"
                               } ]
                            }, {
-                              "type" : "Or",
+                              "name" : "SecondMostRecentCytologyInterpretedAsAscHOrHsil",
+                              "type" : "ExpressionRef"
+                           } ]
+                        }, {
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "SecondMostRecentCytologyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "type" : "Subtract",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 12,
+                                    "unit" : "months",
+                                    "type" : "Quantity"
+                                 } ]
+                              },
+                              "high" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentBiopsyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "name" : "CytologyInterpretedAsAscHOrHsil",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "type" : "After",
                               "operand" : [ {
-                                 "name" : "CytologyInterpretedAsHsil",
-                                 "libraryName" : "Rare",
-                                 "type" : "ExpressionRef"
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentCytologyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
                               }, {
-                                 "name" : "CytologyInterpretedAsAscH",
-                                 "libraryName" : "Rare",
-                                 "type" : "ExpressionRef"
+                                 "type" : "Add",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 2,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
                               } ]
                            } ]
                         }, {
-                           "type" : "After",
+                           "type" : "In",
                            "operand" : [ {
                               "path" : "date",
                               "type" : "Property",
@@ -1529,8 +1634,10 @@
                                  "type" : "ExpressionRef"
                               }
                            }, {
-                              "type" : "Add",
-                              "operand" : [ {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
                                  "path" : "date",
                                  "type" : "Property",
                                  "source" : {
@@ -1538,52 +1645,24 @@
                                     "libraryName" : "Collate",
                                     "type" : "ExpressionRef"
                                  }
-                              }, {
-                                 "value" : 18,
-                                 "unit" : "months",
-                                 "type" : "Quantity"
-                              } ]
-                           } ]
-                        } ]
-                     }, {
-                        "type" : "In",
-                        "operand" : [ {
-                           "path" : "date",
-                           "type" : "Property",
-                           "source" : {
-                              "name" : "MostRecentCytologyReport",
-                              "libraryName" : "Rare",
-                              "type" : "ExpressionRef"
-                           }
-                        }, {
-                           "lowClosed" : false,
-                           "highClosed" : false,
-                           "type" : "Interval",
-                           "low" : {
-                              "path" : "date",
-                              "type" : "Property",
-                              "source" : {
-                                 "name" : "MostRecentBiopsyReport",
-                                 "libraryName" : "Collate",
-                                 "type" : "ExpressionRef"
+                              },
+                              "high" : {
+                                 "type" : "Add",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 3,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
                               }
-                           },
-                           "high" : {
-                              "type" : "Add",
-                              "operand" : [ {
-                                 "path" : "date",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "MostRecentBiopsyReport",
-                                    "libraryName" : "Collate",
-                                    "type" : "ExpressionRef"
-                                 }
-                              }, {
-                                 "value" : 3,
-                                 "unit" : "years",
-                                 "type" : "Quantity"
-                              } ]
-                           }
+                           } ]
                         } ]
                      } ]
                   },
@@ -1638,24 +1717,6 @@
                                  "operand" : [ {
                                     "type" : "And",
                                     "operand" : [ {
-                                       "type" : "GreaterOrEqual",
-                                       "operand" : [ {
-                                          "precision" : "Year",
-                                          "type" : "CalculateAge",
-                                          "operand" : {
-                                             "path" : "birthDate.value",
-                                             "type" : "Property",
-                                             "source" : {
-                                                "name" : "Patient",
-                                                "type" : "ExpressionRef"
-                                             }
-                                          }
-                                       }, {
-                                          "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                          "value" : "21",
-                                          "type" : "Literal"
-                                       } ]
-                                    }, {
                                        "type" : "Less",
                                        "operand" : [ {
                                           "precision" : "Year",
@@ -1673,22 +1734,97 @@
                                           "value" : "25",
                                           "type" : "Literal"
                                        } ]
+                                    }, {
+                                       "type" : "Not",
+                                       "operand" : {
+                                          "name" : "Pregnant",
+                                          "libraryName" : "Dash",
+                                          "type" : "ExpressionRef"
+                                       }
                                     } ]
                                  }, {
-                                    "name" : "HistologyInterpretedAsCin1OrNormal",
+                                    "name" : "SecondMostRecentHistologyInterpretedAsCin1OrNormal",
                                     "libraryName" : "Rare",
                                     "type" : "ExpressionRef"
                                  } ]
                               }, {
-                                 "type" : "Or",
-                                 "operand" : [ {
-                                    "name" : "CytologyInterpretedAsAscusOrAbove",
-                                    "libraryName" : "Collate",
-                                    "type" : "ExpressionRef"
-                                 }, {
-                                    "name" : "CytologyInterpretedAsAis",
+                                 "name" : "SecondMostRecentCytologyInterpretedAsAscHOrHsil",
+                                 "type" : "ExpressionRef"
+                              } ]
+                           }, {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentCytologyReport",
                                     "libraryName" : "Rare",
                                     "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "lowClosed" : false,
+                                 "highClosed" : false,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Subtract",
+                                    "operand" : [ {
+                                       "path" : "date",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "SecondMostRecentBiopsyReport",
+                                          "libraryName" : "Rare",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }, {
+                                       "value" : 12,
+                                       "unit" : "months",
+                                       "type" : "Quantity"
+                                    } ]
+                                 },
+                                 "high" : {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              } ]
+                           } ]
+                        }, {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "name" : "CytologyInterpretedAsAscHOrHsil",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }, {
+                                 "type" : "After",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentCytologyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "type" : "Add",
+                                    "operand" : [ {
+                                       "path" : "date",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "SecondMostRecentBiopsyReport",
+                                          "libraryName" : "Rare",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }, {
+                                       "value" : 2,
+                                       "unit" : "years",
+                                       "type" : "Quantity"
+                                    } ]
                                  } ]
                               } ]
                            }, {
@@ -1709,8 +1845,8 @@
                                     "path" : "date",
                                     "type" : "Property",
                                     "source" : {
-                                       "name" : "MostRecentBiopsyReport",
-                                       "libraryName" : "Collate",
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
                                        "type" : "ExpressionRef"
                                     }
                                  },
@@ -1720,8 +1856,8 @@
                                        "path" : "date",
                                        "type" : "Property",
                                        "source" : {
-                                          "name" : "MostRecentBiopsyReport",
-                                          "libraryName" : "Collate",
+                                          "name" : "SecondMostRecentBiopsyReport",
+                                          "libraryName" : "Rare",
                                           "type" : "ExpressionRef"
                                        }
                                     }, {
@@ -1732,8 +1868,155 @@
                                  }
                               } ]
                            } ]
+                        } ]
+                     }, {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "name" : "HistologyInterpretedAsCin1OrNormal",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "type" : "After",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentBiopsyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "type" : "Add",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 2,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
+                              } ]
+                           } ]
                         }, {
-                           "name" : "SecondMostRecentCytologyInterpretedAsAscHOrHsil",
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentBiopsyReport",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentBiopsyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              },
+                              "high" : {
+                                 "type" : "Add",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 3,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
+                              }
+                           } ]
+                        } ]
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "See Details",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Younger Than 25 (K.1.3)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "A diagnostic excisional procedure is recommended for patients under 25 years, unless the patient is pregnant.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "A diagnostic excisional procedure is recommended in patients when the squamocolumnar junction or the upper limit of all lesions are not fully visualized.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "Less",
+                              "operand" : [ {
+                                 "precision" : "Year",
+                                 "type" : "CalculateAge",
+                                 "operand" : {
+                                    "path" : "birthDate.value",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "Patient",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "25",
+                                 "type" : "Literal"
+                              } ]
+                           }, {
+                              "name" : "HistologyInterpretedAsCin1OrNormal",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           } ]
+                        }, {
+                           "name" : "CytologyInterpretedAsAscH",
+                           "libraryName" : "Rare",
                            "type" : "ExpressionRef"
                         } ]
                      }, {
@@ -1742,7 +2025,7 @@
                            "path" : "date",
                            "type" : "Property",
                            "source" : {
-                              "name" : "SecondMostRecentCytologyReport",
+                              "name" : "MostRecentCytologyReport",
                               "libraryName" : "Rare",
                               "type" : "ExpressionRef"
                            }
@@ -1761,7 +2044,7 @@
                                     "type" : "ExpressionRef"
                                  }
                               }, {
-                                 "value" : 6,
+                                 "value" : 12,
                                  "unit" : "months",
                                  "type" : "Quantity"
                               } ]
@@ -1774,6 +2057,365 @@
                                  "libraryName" : "Collate",
                                  "type" : "ExpressionRef"
                               }
+                           }
+                        } ]
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Cytology",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "name" : "DateOfMostRecentReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "value" : 1,
+                              "unit" : "year",
+                              "type" : "Quantity"
+                           } ]
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Younger Than 25 (K.1.3)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Observation is recommended with cytology in 1 year.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "*Refer to ASCCP Consensus Guideline 2019 Section K.1",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "type" : "Less",
+                                 "operand" : [ {
+                                    "precision" : "Year",
+                                    "type" : "CalculateAge",
+                                    "operand" : {
+                                       "path" : "birthDate.value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "Patient",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "25",
+                                    "type" : "Literal"
+                                 } ]
+                              }, {
+                                 "name" : "HistologyInterpretedAsCin1OrNormal",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              } ]
+                           }, {
+                              "name" : "SecondMostRecentCytologyInterpretedAsAscH",
+                              "type" : "ExpressionRef"
+                           } ]
+                        }, {
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "SecondMostRecentCytologyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "type" : "Subtract",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 12,
+                                    "unit" : "months",
+                                    "type" : "Quantity"
+                                 } ]
+                              },
+                              "high" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentBiopsyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "And",
+                        "operand" : [ {
+                           "name" : "CytologyInterpretedAsNilm",
+                           "libraryName" : "Rare",
+                           "type" : "ExpressionRef"
+                        }, {
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentCytologyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentBiopsyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              },
+                              "high" : {
+                                 "type" : "Add",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 3,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
+                              }
+                           } ]
+                        } ]
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Cytology",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "name" : "DateOfMostRecentReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "value" : 1,
+                              "unit" : "year",
+                              "type" : "Quantity"
+                           } ]
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Younger Than 25 (K.1.3)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Observation is recommended with cytology in 1 year.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "*Refer to ASCCP Consensus Guideline 2019 Section K.1",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "type" : "And",
+                                 "operand" : [ {
+                                    "type" : "Less",
+                                    "operand" : [ {
+                                       "precision" : "Year",
+                                       "type" : "CalculateAge",
+                                       "operand" : {
+                                          "path" : "birthDate.value",
+                                          "type" : "Property",
+                                          "source" : {
+                                             "name" : "Patient",
+                                             "type" : "ExpressionRef"
+                                          }
+                                       }
+                                    }, {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "25",
+                                       "type" : "Literal"
+                                    } ]
+                                 }, {
+                                    "name" : "HistologyInterpretedAsCin1OrNormal",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 } ]
+                              }, {
+                                 "name" : "SecondMostRecentCytologyInterpretedAsAscHOrHsil",
+                                 "type" : "ExpressionRef"
+                              } ]
+                           }, {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentCytologyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "lowClosed" : false,
+                                 "highClosed" : false,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Subtract",
+                                    "operand" : [ {
+                                       "path" : "date",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "MostRecentBiopsyReport",
+                                          "libraryName" : "Collate",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }, {
+                                       "value" : 12,
+                                       "unit" : "months",
+                                       "type" : "Quantity"
+                                    } ]
+                                 },
+                                 "high" : {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              } ]
+                           } ]
+                        }, {
+                           "type" : "Or",
+                           "operand" : [ {
+                              "name" : "CytologyInterpretedAsAscusOrAbove",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "name" : "CytologyInterpretedAsAis",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "In",
+                        "operand" : [ {
+                           "path" : "date",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "MostRecentCytologyReport",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }
+                        }, {
+                           "lowClosed" : false,
+                           "highClosed" : false,
+                           "type" : "Interval",
+                           "low" : {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentBiopsyReport",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           },
+                           "high" : {
+                              "type" : "Add",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentBiopsyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "value" : 3,
+                                 "unit" : "years",
+                                 "type" : "Quantity"
+                              } ]
                            }
                         } ]
                      } ]
@@ -1946,32 +2588,81 @@
                         "operand" : [ {
                            "type" : "And",
                            "operand" : [ {
-                              "type" : "Less",
+                              "type" : "And",
                               "operand" : [ {
-                                 "precision" : "Year",
-                                 "type" : "CalculateAge",
-                                 "operand" : {
-                                    "path" : "birthDate.value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "Patient",
-                                       "type" : "ExpressionRef"
-                                    }
-                                 }
+                                 "type" : "And",
+                                 "operand" : [ {
+                                    "type" : "Less",
+                                    "operand" : [ {
+                                       "precision" : "Year",
+                                       "type" : "CalculateAge",
+                                       "operand" : {
+                                          "path" : "birthDate.value",
+                                          "type" : "Property",
+                                          "source" : {
+                                             "name" : "Patient",
+                                             "type" : "ExpressionRef"
+                                          }
+                                       }
+                                    }, {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "25",
+                                       "type" : "Literal"
+                                    } ]
+                                 }, {
+                                    "name" : "CytologyInterpretedAsNilm",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 } ]
                               }, {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "25",
-                                 "type" : "Literal"
+                                 "name" : "HistologyInterpretedAsCin1OrNormal",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
                               } ]
                            }, {
-                              "name" : "HistologyInterpretedAsCin1OrNormal",
-                              "libraryName" : "Rare",
+                              "name" : "SecondMostRecentCytologyInterpretedAsHsil",
                               "type" : "ExpressionRef"
                            } ]
                         }, {
-                           "name" : "CytologyInterpretedAsAscH",
-                           "libraryName" : "Rare",
-                           "type" : "ExpressionRef"
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "SecondMostRecentCytologyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "type" : "Subtract",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentBiopsyReport",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 12,
+                                    "unit" : "months",
+                                    "type" : "Quantity"
+                                 } ]
+                              },
+                              "high" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentBiopsyReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           } ]
                         } ]
                      }, {
                         "type" : "In",
@@ -1988,7 +2679,16 @@
                            "highClosed" : false,
                            "type" : "Interval",
                            "low" : {
-                              "type" : "Subtract",
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentBiopsyReport",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           },
+                           "high" : {
+                              "type" : "Add",
                               "operand" : [ {
                                  "path" : "date",
                                  "type" : "Property",
@@ -1998,19 +2698,10 @@
                                     "type" : "ExpressionRef"
                                  }
                               }, {
-                                 "value" : 12,
-                                 "unit" : "months",
+                                 "value" : 3,
+                                 "unit" : "years",
                                  "type" : "Quantity"
                               } ]
-                           },
-                           "high" : {
-                              "path" : "date",
-                              "type" : "Property",
-                              "source" : {
-                                 "name" : "MostRecentBiopsyReport",
-                                 "libraryName" : "Collate",
-                                 "type" : "ExpressionRef"
-                              }
                            }
                         } ]
                      } ]
@@ -2021,7 +2712,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Cytology",
+                           "value" : "Colposcopy and Cytology",
                            "type" : "Literal"
                         }
                      }, {
@@ -2051,7 +2742,396 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Observation is recommended with cytology in 1 year.",
+                              "value" : "Observation is recommended with colposcopy and cytology in 1 year.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "*Refer to ASCCP Consensus Guideline 2019 Section K.1",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "type" : "And",
+                                 "operand" : [ {
+                                    "type" : "Less",
+                                    "operand" : [ {
+                                       "precision" : "Year",
+                                       "type" : "CalculateAge",
+                                       "operand" : {
+                                          "path" : "birthDate.value",
+                                          "type" : "Property",
+                                          "source" : {
+                                             "name" : "Patient",
+                                             "type" : "ExpressionRef"
+                                          }
+                                       }
+                                    }, {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "25",
+                                       "type" : "Literal"
+                                    } ]
+                                 }, {
+                                    "name" : "SecondMostRecentHistologyInterpretedAsCin1OrNormal",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 } ]
+                              }, {
+                                 "name" : "CytologyInterpretedAsHsil",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              } ]
+                           }, {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentCytologyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "lowClosed" : false,
+                                 "highClosed" : false,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Subtract",
+                                    "operand" : [ {
+                                       "path" : "date",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "SecondMostRecentBiopsyReport",
+                                          "libraryName" : "Rare",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }, {
+                                       "value" : 12,
+                                       "unit" : "months",
+                                       "type" : "Quantity"
+                                    } ]
+                                 },
+                                 "high" : {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              } ]
+                           } ]
+                        }, {
+                           "name" : "HistologyInterpretedAsCin1OrNormal",
+                           "libraryName" : "Rare",
+                           "type" : "ExpressionRef"
+                        } ]
+                     }, {
+                        "type" : "In",
+                        "operand" : [ {
+                           "path" : "date",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "MostRecentBiopsyReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }
+                        }, {
+                           "lowClosed" : false,
+                           "highClosed" : false,
+                           "type" : "Interval",
+                           "low" : {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "SecondMostRecentBiopsyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           },
+                           "high" : {
+                              "type" : "Add",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentBiopsyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "value" : 3,
+                                 "unit" : "years",
+                                 "type" : "Quantity"
+                              } ]
+                           }
+                        } ]
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Colposcopy and Cytology",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "name" : "DateOfMostRecentReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "value" : 1,
+                              "unit" : "year",
+                              "type" : "Quantity"
+                           } ]
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Younger Than 25 (K.1.3)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Observation is recommended with colposcopy and cytology in 1 year.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "*Refer to ASCCP Consensus Guideline 2019 Section K.1",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "type" : "And",
+                              "operand" : [ {
+                                 "type" : "And",
+                                 "operand" : [ {
+                                    "type" : "Less",
+                                    "operand" : [ {
+                                       "precision" : "Year",
+                                       "type" : "CalculateAge",
+                                       "operand" : {
+                                          "path" : "birthDate.value",
+                                          "type" : "Property",
+                                          "source" : {
+                                             "name" : "Patient",
+                                             "type" : "ExpressionRef"
+                                          }
+                                       }
+                                    }, {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "25",
+                                       "type" : "Literal"
+                                    } ]
+                                 }, {
+                                    "name" : "SecondMostRecentHistologyInterpretedAsCin1OrNormal",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 } ]
+                              }, {
+                                 "name" : "SecondMostRecentCytologyInterpretedAsHsil",
+                                 "type" : "ExpressionRef"
+                              } ]
+                           }, {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentCytologyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "lowClosed" : false,
+                                 "highClosed" : false,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Subtract",
+                                    "operand" : [ {
+                                       "path" : "date",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "SecondMostRecentBiopsyReport",
+                                          "libraryName" : "Rare",
+                                          "type" : "ExpressionRef"
+                                       }
+                                    }, {
+                                       "value" : 12,
+                                       "unit" : "months",
+                                       "type" : "Quantity"
+                                    } ]
+                                 },
+                                 "high" : {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }
+                              } ]
+                           } ]
+                        }, {
+                           "type" : "In",
+                           "operand" : [ {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "MostRecentBiopsyReport",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "lowClosed" : false,
+                              "highClosed" : false,
+                              "type" : "Interval",
+                              "low" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentBiopsyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              },
+                              "high" : {
+                                 "type" : "Add",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "SecondMostRecentBiopsyReport",
+                                       "libraryName" : "Rare",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 }, {
+                                    "value" : 3,
+                                    "unit" : "years",
+                                    "type" : "Quantity"
+                                 } ]
+                              }
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "In",
+                        "operand" : [ {
+                           "path" : "date",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "MostRecentCytologyReport",
+                              "libraryName" : "Rare",
+                              "type" : "ExpressionRef"
+                           }
+                        }, {
+                           "lowClosed" : false,
+                           "highClosed" : false,
+                           "type" : "Interval",
+                           "low" : {
+                              "path" : "date",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "SecondMostRecentBiopsyReport",
+                                 "libraryName" : "Rare",
+                                 "type" : "ExpressionRef"
+                              }
+                           },
+                           "high" : {
+                              "type" : "Add",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "SecondMostRecentBiopsyReport",
+                                    "libraryName" : "Rare",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "value" : 3,
+                                 "unit" : "years",
+                                 "type" : "Quantity"
+                              } ]
+                           }
+                        } ]
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Colposcopy and Cytology",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "name" : "DateOfMostRecentReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "value" : 1,
+                              "unit" : "year",
+                              "type" : "Quantity"
+                           } ]
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Younger Than 25 (K.1.3)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Observation is recommended with colposcopy and cytology in 1 year.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",

--- a/test/ManagementSpecialPopulations/cases/Young33HSILCytoCin1Persists.yml
+++ b/test/ManagementSpecialPopulations/cases/Young33HSILCytoCin1Persists.yml
@@ -1,0 +1,34 @@
+---
+name: Younger Than 25 Cytologic HSIL or ASC-H With Histologic CIN1 Persists for 2 years 3.3
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 2000-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+- 
+  $iterate: *ASCHOrHSILTwoYearsAgo
+- 
+  $iterate: *HistologyCin1OrNormalTwoYearsAgo
+- 
+  $iterate: *ASCHOrHSILThisYear
+-
+  $iterate: *HistologyCin1OrNormalThisYear
+  
+results:
+  Recommendation: 
+    short: 'See Details'
+    date: '2021-06-02'
+    group: 'Younger Than 25 (K.1.3)'
+    details:
+    - 'A diagnostic excisional procedure is recommended for patients under 25 years, unless the patient is pregnant.'
+    - 'A diagnostic excisional procedure is recommended in patients when the squamocolumnar junction or the upper limit of all lesions are not fully visualized.'
+  WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/resources.yml
+++ b/test/ManagementSpecialPopulations/cases/resources.yml
@@ -31,13 +31,13 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#285836003 Cervical intraepithelial neoplasia grade 1 (disorder)
-    effectiveDateTime: 2019-05-01
+    effectiveDateTime: 2019-04-01
   - resourceType: DiagnosticReport
     code: LOINC#65753-6 Cervix Pathology biopsy report
     status: final
     conclusionCode:
     - SNOMEDCT#165324008 Biopsy result normal (finding) 
-    effectiveDateTime: 2019-05-01
+    effectiveDateTime: 2019-04-01
 - &ASCUSOrAboveOrAISThisYear
   - resourceType: DiagnosticReport
     code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain

--- a/test/WithObsManagementSpecialPopulations/cases/Young33HSILCytoPersists.yml
+++ b/test/WithObsManagementSpecialPopulations/cases/Young33HSILCytoPersists.yml
@@ -27,14 +27,14 @@ data:
   status: final
   result:
   - reference: Observation/789
-  effectiveDateTime: 2019-05-01
+  effectiveDateTime: 2019-04-30
 - 
   resourceType: Observation
   id: 789
   code: LOINC#65753-6 Cervix Pathology biopsy report
   status: final
   valueCodeableConcept: SNOMEDCT#285836003 Cervical intraepithelial neoplasia grade 1 (disorder)
-  effectiveDateTime: 2019-05-01
+  effectiveDateTime: 2019-04-30
 - 
   resourceType: DiagnosticReport
   code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain


### PR DESCRIPTION
This addresses the latest L2 observation logic for Section K.1 Heading 3 - Management of Histology of Less than CIN2 Preceded by Cytology ASC-H and HSIL in Patients Younger than 25 Year

The logic was updated to check for cytology or histology after 'CIN1 or less preceded by ASC-H/HSIL' by looking for a count of < 2. This means there are two possible cases: the cytology or histology result is present or there are zero results present. Adding a COUNT clause to the CQL logic complicates looking for the original CIN1 or less result.
Therefore, to simplify the logic, these checks were added as individual cases (look for zero results after the CIN1 or less, look for one result after the CIN1 or less). This adds some redundancy to the code, but makes inspection of the code easier. 

The time range for the "persists for 2 years" is specified as ">2 years" so test results which were *exactly* two years apart in the test cases need to be adjusted. 

Additional logic diagrams have been linked to the JIRA ticket CCSMCDS-45 for this PR.