### PR TITLE
Restrict Risk Table 3 Lookup

### DIFF
--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -488,7 +488,7 @@ define ErrataRecommendation:
     when ( // Errata Recommendation 3.1.1: ASC-US Alone
       AgeInYears() >= 25 and
       CytologyAloneInterpretedAsAscus and
-      Collate.HasNoBiopsyOrTreatmentAfterDate(MostRecentCytologyAlone.date) and
+      IsMostRecentTest(MostRecentCytologyAlone.date) and
       Collate.HasNoBiopsyOrTreatmentAfterDate(MostRecentCytologyAlone.date)
     ) then
       {

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -157,11 +157,14 @@ define SurveillanceManagementRecommendation:
 // COMMON ABNORMALITY #3: Receipt of colposcopy/biopsy results
 // Table 3
 define LookUpTable3: // NOTE: Review whether we need to look at history going further back
-  RiskTableLookup.GetColposcopyResultsManagement(
-    Collate.ReferringHpvResult,
-    Collate.ReferringCytologyResult,
-    Collate.MostRecentBiopsyResult
-  )
+  if IsMostRecentTest(Collate.MostRecentBiopsyReport.date) then
+    RiskTableLookup.GetColposcopyResultsManagement(
+      Collate.ReferringHpvResult,
+      Collate.ReferringCytologyResult,
+      Collate.MostRecentBiopsyResult
+    )
+  else
+    DefaultLookupTableReturnValue
 
 define RowTable3:
   RiskTableLookup.GetRowTable3(
@@ -437,6 +440,9 @@ define AnyCytologyInterpretedAsAscusOrAbove:
 define LastKnownCytologyInterpretedAsAscusOrAbove:
   First(AnyCytologyInterpretedAsAscusOrAbove)
 
+define function IsMostRecentTest(d System.DateTime):
+  Collate.MostRecentReport = d
+
 define ErrataRecommendation:
   case
     when ( // Errata Recommendation 3.2.2.a: Low grade cytology followed by persistent abnormality
@@ -482,7 +488,7 @@ define ErrataRecommendation:
     when ( // Errata Recommendation 3.1.1: ASC-US Alone
       AgeInYears() >= 25 and
       CytologyAloneInterpretedAsAscus and
-      Collate.MostRecentReport = MostRecentCytologyAlone.date and
+      Collate.HasNoBiopsyOrTreatmentAfterDate(MostRecentCytologyAlone.date) and
       Collate.HasNoBiopsyOrTreatmentAfterDate(MostRecentCytologyAlone.date)
     ) then
       {
@@ -495,7 +501,7 @@ define ErrataRecommendation:
     when ( // Errata Recommendation 3.1.2: LSIL Alone
       AgeInYears() >= 25 and
       CytologyAloneInterpretedAsLsil and
-      Collate.MostRecentReport = MostRecentCytologyAlone.date and
+      IsMostRecentTest(MostRecentCytologyAlone.date) and
       Collate.HasNoBiopsyOrTreatmentAfterDate(MostRecentCytologyAlone.date)
     ) then
       {
@@ -508,7 +514,7 @@ define ErrataRecommendation:
     when ( // Errata Recommendation 3.1.3: HSIL or SCC Alone
       AgeInYears() >= 25 and
       CytologyAloneInterpretedAsHsil and
-      Collate.MostRecentReport = MostRecentCytologyAlone.date and
+      IsMostRecentTest(MostRecentCytologyAlone.date) and
       Collate.HasNoBiopsyOrTreatmentAfterDate(MostRecentCytologyAlone.date)
     ) then
       {

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -596,26 +596,69 @@
                }
             }
          }, {
+            "name" : "IsMostRecentTest",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "type" : "Equal",
+               "operand" : [ {
+                  "name" : "MostRecentReport",
+                  "libraryName" : "Collate",
+                  "type" : "ExpressionRef"
+               }, {
+                  "name" : "d",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "d",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
             "name" : "LookUpTable3",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "name" : "GetColposcopyResultsManagement",
-               "libraryName" : "RiskTableLookup",
-               "type" : "FunctionRef",
-               "operand" : [ {
-                  "name" : "ReferringHpvResult",
-                  "libraryName" : "Collate",
+               "type" : "If",
+               "condition" : {
+                  "name" : "IsMostRecentTest",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "path" : "date",
+                     "type" : "Property",
+                     "source" : {
+                        "name" : "MostRecentBiopsyReport",
+                        "libraryName" : "Collate",
+                        "type" : "ExpressionRef"
+                     }
+                  } ]
+               },
+               "then" : {
+                  "name" : "GetColposcopyResultsManagement",
+                  "libraryName" : "RiskTableLookup",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "name" : "ReferringHpvResult",
+                     "libraryName" : "Collate",
+                     "type" : "ExpressionRef"
+                  }, {
+                     "name" : "ReferringCytologyResult",
+                     "libraryName" : "Collate",
+                     "type" : "ExpressionRef"
+                  }, {
+                     "name" : "MostRecentBiopsyResult",
+                     "libraryName" : "Collate",
+                     "type" : "ExpressionRef"
+                  } ]
+               },
+               "else" : {
+                  "name" : "DefaultLookupTableReturnValue",
                   "type" : "ExpressionRef"
-               }, {
-                  "name" : "ReferringCytologyResult",
-                  "libraryName" : "Collate",
-                  "type" : "ExpressionRef"
-               }, {
-                  "name" : "MostRecentBiopsyResult",
-                  "libraryName" : "Collate",
-                  "type" : "ExpressionRef"
-               } ]
+               }
             }
          }, {
             "name" : "RowTable3",
@@ -686,11 +729,7 @@
                   }
                },
                "else" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  }
+                  "type" : "Null"
                }
             }
          }, {
@@ -1353,8 +1392,12 @@
                   "name" : "PostColposcopyManagementRecommendation",
                   "type" : "ExpressionRef"
                }, {
-                  "name" : "ColposcopyResultsManagementRecommendation",
-                  "type" : "ExpressionRef"
+                  "asType" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "As",
+                  "operand" : {
+                     "name" : "ColposcopyResultsManagementRecommendation",
+                     "type" : "ExpressionRef"
+                  }
                }, {
                   "asType" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "As",
@@ -2619,12 +2662,10 @@
                               "type" : "ExpressionRef"
                            } ]
                         }, {
-                           "type" : "Equal",
+                           "name" : "HasNoBiopsyOrTreatmentAfterDate",
+                           "libraryName" : "Collate",
+                           "type" : "FunctionRef",
                            "operand" : [ {
-                              "name" : "MostRecentReport",
-                              "libraryName" : "Collate",
-                              "type" : "ExpressionRef"
-                           }, {
                               "path" : "date",
                               "type" : "Property",
                               "source" : {
@@ -2703,12 +2744,9 @@
                               "type" : "ExpressionRef"
                            } ]
                         }, {
-                           "type" : "Equal",
+                           "name" : "IsMostRecentTest",
+                           "type" : "FunctionRef",
                            "operand" : [ {
-                              "name" : "MostRecentReport",
-                              "libraryName" : "Collate",
-                              "type" : "ExpressionRef"
-                           }, {
                               "path" : "date",
                               "type" : "Property",
                               "source" : {
@@ -2787,12 +2825,9 @@
                               "type" : "ExpressionRef"
                            } ]
                         }, {
-                           "type" : "Equal",
+                           "name" : "IsMostRecentTest",
+                           "type" : "FunctionRef",
                            "operand" : [ {
-                              "name" : "MostRecentReport",
-                              "libraryName" : "Collate",
-                              "type" : "ExpressionRef"
-                           }, {
                               "path" : "date",
                               "type" : "Property",
                               "source" : {

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -2662,8 +2662,7 @@
                               "type" : "ExpressionRef"
                            } ]
                         }, {
-                           "name" : "HasNoBiopsyOrTreatmentAfterDate",
-                           "libraryName" : "Collate",
+                           "name" : "IsMostRecentTest",
                            "type" : "FunctionRef",
                            "operand" : [ {
                               "path" : "date",


### PR DESCRIPTION
**Jira Ticket**: This PR addresses **[CCSMCDS-75](https://jira.mitre.org/browse/CCSMCDS-75)**

**Description**: Only return a value from lookup table 3 if the biopsy result is the most recent result.

**Notes on Patient Testing**:
The following test patients were affected by this PR:

1. SJ42
   - Former recommendation: Treatment from Risk Table 3, because of a previous CIN2 result
   - Clinical Situation: this patient is in surveillance for CIN2 (they chose Observation as opposed to treatment)
   - Current recommendation: Colposcopy from Errata
   - Analysis: Makes sense, since results from follow up cotesting during observation of CIN2 would lead to this patient getting another colpo

2. PN33
   - Former recommendation: Treatment from Risk Table 3, because of a previous CIN2 result
   - Clinical Situation: this patient is in surveillance for CIN2 (they chose Observation as opposed to treatment)
   - Current recommendation: Colposcopy from Risk Table 1
   - Analysis: I believe this makes sense, since the persistent ASC-US / HPV+ cotest after the CIN2 would lead this patient to get another colposcopy during Observation.

3. MT53
   - Former recommendation: 1-year-surveillance from risk table 3, because of former CIN1 result.
   - Clinical Situation: this patient is in surveillance after a low-grade biopsy
   -  Current recommendation: Unknown, since this case was discovered with the pilot partners after our mock test cases were created
   - Analysis: I believe this patient would now receive a colposcopy rec from the errata, due to subsequent ASC-US / HPV+ cotest results during surveillance of CIN1. May also come from section I, or risk table 4, however, either way, should be a colposcopy recommendation.