### PR TITLE
Update recommendation text relative to latest test

### DIFF
--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -491,7 +491,7 @@ define ErrataRecommendation:
         short: 'Reflex HPV',
         date: Today(),
         details: {
-          'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology within 1 year from date of most recent test.'
+          'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year from date of most recent test.'
         }
       }
     when ( // Errata Recommendation 3.1.2: LSIL Alone
@@ -571,7 +571,7 @@ define ErrataRecommendation:
         short: 'Surveillance',
         date: Collate.DateOfMostRecentReport + 1 years,
         details: {
-          'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'
+          'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
         }
       }
     else
@@ -594,13 +594,13 @@ define TreatmentWithPregnancyConcernsRecommendationText:
   'If the patient is currently pregnant, endocervical curettage, endometrial biopsy, and treatment without biopsy are unacceptable.'
 
 define OneYearSurveillanceRecommendationText:
-  'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+  'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
   
 define ThreeYearSurveillanceRecommendationText:
-  'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+  'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
   
 define FiveYearSurveillanceRecommendationText:
-  'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+  'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
 
 define FiveYearSurveillanceIntervalText:
   'Future testing is recommended at 5-year intervals.'  

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -571,7 +571,7 @@ define ErrataRecommendation:
         short: 'Surveillance',
         date: Collate.DateOfMostRecentReport + 1 years,
         details: {
-          'Primary HPV testing or cotesting is recommended in one year.'
+          'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'
         }
       }
     else
@@ -582,25 +582,28 @@ define ReflexTestingRecommendationText:
   'Reflex testing with cervical cytology is indicated.'
 
 define Pap6MonthIntervalText:
-  'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+  'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   
 define Pap1YearIntervalText:
-  'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+  'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
  
 define Pap3YearIntervalText:
-  'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+  'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   
 define TreatmentWithPregnancyConcernsRecommendationText:
   'If the patient is currently pregnant, endocervical curettage, endometrial biopsy, and treatment without biopsy are unacceptable.'
 
 define OneYearSurveillanceRecommendationText:
-  'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-
+//  'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
+  'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+  
 define ThreeYearSurveillanceRecommendationText:
-  'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
+//  'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
+  'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
   
 define FiveYearSurveillanceRecommendationText:
-  'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
+//  'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
+  'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
 
 define ColposcopyRecommendationText:
   'Colposcopy is recommended.'

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -491,7 +491,7 @@ define ErrataRecommendation:
         short: 'Reflex HPV',
         date: Today(),
         details: {
-          'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
+          'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology within 1 year from date of most recent test.'
         }
       }
     when ( // Errata Recommendation 3.1.2: LSIL Alone
@@ -600,7 +600,10 @@ define ThreeYearSurveillanceRecommendationText:
   'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
   
 define FiveYearSurveillanceRecommendationText:
-  'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+  'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+
+define FiveYearSurveillanceIntervalText:
+  'Future testing is recommended at 5-year intervals.'  
 
 define ColposcopyRecommendationText:
   'Colposcopy is recommended.'
@@ -774,6 +777,7 @@ define Action:
         date: Collate.DateOfMostRecentReport + 5 years,
         details: {
           FiveYearSurveillanceRecommendationText,
+          FiveYearSurveillanceIntervalText,
           Pap3YearIntervalText
         }
       }
@@ -786,6 +790,7 @@ define Action:
         date: Collate.DateOfMostRecentReport + 5 years,
         details: {
           FiveYearSurveillanceRecommendationText,
+          FiveYearSurveillanceIntervalText,
           Pap3YearIntervalText
         }
       }

--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -594,15 +594,12 @@ define TreatmentWithPregnancyConcernsRecommendationText:
   'If the patient is currently pregnant, endocervical curettage, endometrial biopsy, and treatment without biopsy are unacceptable.'
 
 define OneYearSurveillanceRecommendationText:
-//  'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
   'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
   
 define ThreeYearSurveillanceRecommendationText:
-//  'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
   'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
   
 define FiveYearSurveillanceRecommendationText:
-//  'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
   'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
 
 define ColposcopyRecommendationText:

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -2661,7 +2661,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.",
+                              "value" : "Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology within 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3516,7 +3516,16 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.",
+               "value" : "Primary HPV testing or cotesting is recommended within 5 years of most recent test.",
+               "type" : "Literal"
+            }
+         }, {
+            "name" : "FiveYearSurveillanceIntervalText",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "valueType" : "{urn:hl7-org:elm-types:r1}String",
+               "value" : "Future testing is recommended at 5-year intervals.",
                "type" : "Literal"
             }
          }, {
@@ -4168,6 +4177,9 @@
                               "name" : "FiveYearSurveillanceRecommendationText",
                               "type" : "ExpressionRef"
                            }, {
+                              "name" : "FiveYearSurveillanceIntervalText",
+                              "type" : "ExpressionRef"
+                           }, {
                               "name" : "Pap3YearIntervalText",
                               "type" : "ExpressionRef"
                            } ]
@@ -4236,6 +4248,9 @@
                            "type" : "List",
                            "element" : [ {
                               "name" : "FiveYearSurveillanceRecommendationText",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "name" : "FiveYearSurveillanceIntervalText",
                               "type" : "ExpressionRef"
                            }, {
                               "name" : "Pap3YearIntervalText",

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -3137,7 +3137,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary HPV testing or cotesting is recommended in one year.",
+                              "value" : "Primary HPV testing or cotesting is recommended within one year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3462,7 +3462,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.",
+               "value" : "If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3471,7 +3471,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.",
+               "value" : "If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3480,7 +3480,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.",
+               "value" : "If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3498,7 +3498,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Repeat testing in 1 year with primary HPV testing or cotesting is recommended.",
+               "value" : "Primary HPV testing or cotesting is recommended within 1 year of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3507,7 +3507,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Repeat testing in 3 years with primary HPV testing or cotesting is recommended.",
+               "value" : "Primary HPV testing or cotesting is recommended within 3 years of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3516,7 +3516,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.",
+               "value" : "Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.",
                "type" : "Literal"
             }
          }, {

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -2661,7 +2661,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology within 1 year from date of most recent test.",
+                              "value" : "Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3137,7 +3137,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary HPV testing or cotesting is recommended within one year from date of most recent test.",
+                              "value" : "Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3498,7 +3498,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Primary HPV testing or cotesting is recommended within 1 year of most recent test.",
+               "value" : "Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3507,7 +3507,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Primary HPV testing or cotesting is recommended within 3 years of most recent test.",
+               "value" : "Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.",
                "type" : "Literal"
             }
          }, {
@@ -3516,7 +3516,7 @@
             "accessLevel" : "Public",
             "expression" : {
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
-               "value" : "Primary HPV testing or cotesting is recommended within 5 years of most recent test.",
+               "value" : "Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.",
                "type" : "Literal"
             }
          }, {

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -1341,7 +1341,7 @@ define RecommendationForHistologyResults:
         date: Today() + 1 year,
         group: 'Managing Histology (I.3)',
         details: {
-          'Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.'
+          'Primary HPV testing or cotesting in 1 year from date of most recent test is recommended.'
         }
       }
     when ( // I3.2
@@ -1516,7 +1516,7 @@ define RecommendationForHistologyResults:
         date: Today(),
         group: 'Managing Histology (I.4.3.1)',
         details: {
-          'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
+          'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'
         }
       }
     when ( // I4.4
@@ -1590,7 +1590,7 @@ define RecommendationForHistologyResults:
         date: Today(),
         group: 'Managing Histology (I.4.1)',
         details: {
-          'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy within 1 year of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.',
+          'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy in 1 year from date of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.',
           'Observation is only acceptable when the initial colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and that the endocervical sampling, if collected, was less than CIN 2.'
         }
       }

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -1341,7 +1341,7 @@ define RecommendationForHistologyResults:
         date: Today() + 1 year,
         group: 'Managing Histology (I.3)',
         details: {
-          'Primary HPV testing or cotesting in 1 year is recommended.'
+          'Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.'
         }
       }
     when ( // I3.2
@@ -1516,7 +1516,7 @@ define RecommendationForHistologyResults:
         date: Today(),
         group: 'Managing Histology (I.4.3.1)',
         details: {
-          'Primary hrHPV testing or cotesting is recommended in 1 year.'
+          'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
         }
       }
     when ( // I4.4
@@ -1590,7 +1590,7 @@ define RecommendationForHistologyResults:
         date: Today(),
         group: 'Managing Histology (I.4.1)',
         details: {
-          'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy in 1 year, or review of the cytologic, histologic and colposcopic findings are acceptable.',
+          'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy within 1 year of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.',
           'Observation is only acceptable when the initial colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and that the endocervical sampling, if collected, was less than CIN 2.'
         }
       }
@@ -1607,7 +1607,7 @@ define RecommendationForHistologyResults:
         date: Today(),
         group: 'Managing Histology (I.4.2)',
         details: {
-          'Observation with primary HPV testing or cotesting at 1 year is recommended if the colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and the endocervical sampling, if collected, was negative.',
+          'Observation with primary HPV testing or cotesting at 1 year after the colposcopy is recommended if the colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and the endocervical sampling, if collected, was negative.',
           'A diagnostic excisional procedure is not recommended.'
         }
       }

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -402,7 +402,7 @@ define RecommendationForRareCytology:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Rare Cytology (G.1.4)',
         details: {
-          'Cotesting at 1 and 2 years is recommended.',
+          'Cotesting at 1 and 2 years from date of most recent test is recommended.',
           'If both cotests are negative, repeat cotesting at 3 years is recommended.',
           'If any test is abnormal, then colposcopy is recommended.'
         }

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -3344,7 +3344,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cotesting at 1 and 2 years is recommended.",
+                              "value" : "Cotesting at 1 and 2 years from date of most recent test is recommended.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -10464,7 +10464,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.",
+                              "value" : "Primary HPV testing or cotesting in 1 year from date of most recent test is recommended.",
                               "type" : "Literal"
                            } ]
                         }
@@ -11844,7 +11844,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.",
+                              "value" : "Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -12449,7 +12449,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy within 1 year of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.",
+                              "value" : "Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy in 1 year from date of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -10464,7 +10464,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary HPV testing or cotesting in 1 year is recommended.",
+                              "value" : "Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.",
                               "type" : "Literal"
                            } ]
                         }
@@ -11844,7 +11844,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary hrHPV testing or cotesting is recommended in 1 year.",
+                              "value" : "Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -12449,7 +12449,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy in 1 year, or review of the cytologic, histologic and colposcopic findings are acceptable.",
+                              "value" : "Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy within 1 year of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -12545,7 +12545,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Observation with primary HPV testing or cotesting at 1 year is recommended if the colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and the endocervical sampling, if collected, was negative.",
+                              "value" : "Observation with primary HPV testing or cotesting at 1 year after the colposcopy is recommended if the colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and the endocervical sampling, if collected, was negative.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -617,7 +617,7 @@ define RecommendationForImmunosuppressedPatients:
         date: Collate.DateOfMostRecentReport + 6 months,
         group: 'Immunosuppressed (K.3)',
         details: {
-          'Cervical cytology is recommended within 6 to 12 months from date of most recent test in this immunocompromised patient.'
+          'Cervical cytology is recommended in 6 to 12 months from date of most recent test in this immunocompromised patient.'
         }
       }   
     else

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -286,7 +286,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.3)',
         details: {
-          'Observation is recommended with colposcopy and cytology in 1 year.',
+          'Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.',
           'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
           '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
         }
@@ -728,7 +728,9 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Hysterectomy (K.4)',
         details: {
-          'Primary hrHPV testing or cotesting is recommended every 3 years after date of most recent test for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
+          'Primary hrHPV testing or cotesting is recommended within 3 years of most recent test.',
+          'Testing should continue for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.',
+          'Future testing is recommended at 3-year intervals.'
         }
       }
     when ( // no hysterectomy date

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -302,7 +302,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.3)',
         details: {
-          'Observation is recommended with cytology in 1 year.',
+          'Observation is recommended with cytology within 1 year from date of most recent test.',
           'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
           '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
         }
@@ -342,7 +342,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.4)',
         details: {
-          'Colposcopy and cervical cytology should be performed in 1 year.'
+          'Colposcopy and cervical cytology should be performed within 1 year from date of most recent test.'
         }
       }
     when ( // Heading4.1
@@ -418,7 +418,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Younger Than 25 (K.1.1)',
         details: {
-          'Repeat testing is indicated in 3 years. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
+          'Repeat testing is indicated within 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
         }
       }
     when ( // 5a
@@ -430,7 +430,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.1)',
         details: {
-          'Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+          'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
         }
       }
     when ( // #5b
@@ -466,7 +466,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.1)',
         details: {
-          'Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+          'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
         }
       }
     else
@@ -617,7 +617,7 @@ define RecommendationForImmunosuppressedPatients:
         date: Collate.DateOfMostRecentReport + 6 months,
         group: 'Immunosuppressed (K.3)',
         details: {
-          'Cervical cytology is recommended in 6 to 12 months in this immunocompromised patient.'
+          'Cervical cytology is recommended within 6 to 12 months from date of most recent test in this immunocompromised patient.'
         }
       }   
     else
@@ -728,7 +728,7 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Hysterectomy (K.4)',
         details: {
-          'Primary hrHPV testing or cotesting is recommended every 3 years for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
+          'Primary hrHPV testing or cotesting is recommended every 3 years after date of most recent test for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
         }
       }
     when ( // no hysterectomy date

--- a/cql/ManageSpecialPopulation.cql
+++ b/cql/ManageSpecialPopulation.cql
@@ -286,7 +286,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.3)',
         details: {
-          'Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.',
+          'Observation is recommended with colposcopy and cytology in 1 year from date of most recent test.',
           'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
           '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
         }
@@ -302,7 +302,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.3)',
         details: {
-          'Observation is recommended with cytology within 1 year from date of most recent test.',
+          'Observation is recommended with cytology in 1 year from date of most recent test.',
           'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*',
           '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
         }
@@ -342,7 +342,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.4)',
         details: {
-          'Colposcopy and cervical cytology should be performed within 1 year from date of most recent test.'
+          'Colposcopy and cervical cytology should be performed in 1 year from date of most recent test.'
         }
       }
     when ( // Heading4.1
@@ -418,7 +418,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Younger Than 25 (K.1.1)',
         details: {
-          'Repeat testing is indicated within 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
+          'Repeat testing is indicated in 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
         }
       }
     when ( // 5a
@@ -430,7 +430,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.1)',
         details: {
-          'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+          'Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
         }
       }
     when ( // #5b
@@ -466,7 +466,7 @@ define RecommendationForPatientsYoungerThan25:
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Younger Than 25 (K.1.1)',
         details: {
-          'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+          'Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
         }
       }
     else
@@ -728,7 +728,7 @@ define RecommendationForManagingPatientsAfterHysterectomy:
         date: Collate.DateOfMostRecentReport + 3 years,
         group: 'Hysterectomy (K.4)',
         details: {
-          'Primary hrHPV testing or cotesting is recommended within 3 years of most recent test.',
+          'Primary hrHPV testing or cotesting is recommended in 3 years from date of most recent test.',
           'Testing should continue for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.',
           'Future testing is recommended at 3-year intervals.'
         }

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -1924,7 +1924,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.",
+                              "value" : "Observation is recommended with colposcopy and cytology in 1 year from date of most recent test.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -2051,7 +2051,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Observation is recommended with cytology within 1 year from date of most recent test.",
+                              "value" : "Observation is recommended with cytology in 1 year from date of most recent test.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -2322,7 +2322,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Colposcopy and cervical cytology should be performed within 1 year from date of most recent test.",
+                              "value" : "Colposcopy and cervical cytology should be performed in 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -2771,7 +2771,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Repeat testing is indicated within 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.",
+                              "value" : "Repeat testing is indicated in 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.",
                               "type" : "Literal"
                            } ]
                         }
@@ -2841,7 +2841,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
+                              "value" : "Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3018,7 +3018,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
+                              "value" : "Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
                               "type" : "Literal"
                            } ]
                         }
@@ -4672,7 +4672,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary hrHPV testing or cotesting is recommended within 3 years of most recent test.",
+                              "value" : "Primary hrHPV testing or cotesting is recommended in 3 years from date of most recent test.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -1924,7 +1924,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Observation is recommended with colposcopy and cytology in 1 year.",
+                              "value" : "Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -4672,7 +4672,15 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary hrHPV testing or cotesting is recommended every 3 years after date of most recent test for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.",
+                              "value" : "Primary hrHPV testing or cotesting is recommended within 3 years of most recent test.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Testing should continue for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Future testing is recommended at 3-year intervals.",
                               "type" : "Literal"
                            } ]
                         }

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -3848,7 +3848,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cervical cytology is recommended within 6 to 12 months from date of most recent test in this immunocompromised patient.",
+                              "value" : "Cervical cytology is recommended in 6 to 12 months from date of most recent test in this immunocompromised patient.",
                               "type" : "Literal"
                            } ]
                         }

--- a/cql/ManageSpecialPopulation.json
+++ b/cql/ManageSpecialPopulation.json
@@ -2051,7 +2051,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Observation is recommended with cytology in 1 year.",
+                              "value" : "Observation is recommended with cytology within 1 year from date of most recent test.",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -2322,7 +2322,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Colposcopy and cervical cytology should be performed in 1 year.",
+                              "value" : "Colposcopy and cervical cytology should be performed within 1 year from date of most recent test.",
                               "type" : "Literal"
                            } ]
                         }
@@ -2771,7 +2771,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Repeat testing is indicated in 3 years. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.",
+                              "value" : "Repeat testing is indicated within 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.",
                               "type" : "Literal"
                            } ]
                         }
@@ -2841,7 +2841,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
+                              "value" : "Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3018,7 +3018,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
+                              "value" : "Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.",
                               "type" : "Literal"
                            } ]
                         }
@@ -3848,7 +3848,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Cervical cytology is recommended in 6 to 12 months in this immunocompromised patient.",
+                              "value" : "Cervical cytology is recommended within 6 to 12 months from date of most recent test in this immunocompromised patient.",
                               "type" : "Literal"
                            } ]
                         }
@@ -4672,7 +4672,7 @@
                            "type" : "List",
                            "element" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "Primary hrHPV testing or cotesting is recommended every 3 years for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.",
+                              "value" : "Primary hrHPV testing or cotesting is recommended every 3 years after date of most recent test for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.",
                               "type" : "Literal"
                            } ]
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm-cds-with-tests",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm-cds-with-tests",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-testing": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm-cds-with-tests",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "This repository contains clinical decision support (CDS) which provides recommendations for cervical cancer screening and management (CCSM).",
   "exports": {
     "./fhir/ActivityDefinition/*.js": "./dist/fhir/ActivityDefinition/*.js",

--- a/test/ManagementErrata/cases/3.1.1-CytologyAloneAscus.yml
+++ b/test/ManagementErrata/cases/3.1.1-CytologyAloneAscus.yml
@@ -25,4 +25,4 @@ results:
     date: '2021-06-02'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology within 1 year from date of most recent test.'
+    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.1.1-CytologyAloneAscus.yml
+++ b/test/ManagementErrata/cases/3.1.1-CytologyAloneAscus.yml
@@ -25,4 +25,4 @@ results:
     date: '2021-06-02'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology in 1 year.'
+    - 'Reflex HPV testing is preferred. If HPV testing is not feasible, repeat cytology within 1 year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegative.yml
+++ b/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegative.yml
@@ -42,4 +42,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegative.yml
+++ b/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegative.yml
@@ -42,4 +42,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended in one year.'
+    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegativeNilm.yml
+++ b/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegativeNilm.yml
@@ -50,4 +50,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended in one year.'
+    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegativeNilm.yml
+++ b/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegativeNilm.yml
@@ -50,4 +50,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegative.yml
+++ b/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegative.yml
@@ -35,4 +35,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegative.yml
+++ b/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegative.yml
@@ -35,4 +35,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended in one year.'
+    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegativeNilm.yml
+++ b/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegativeNilm.yml
@@ -43,4 +43,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended in one year.'
+    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'

--- a/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegativeNilm.yml
+++ b/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegativeNilm.yml
@@ -43,4 +43,4 @@ results:
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:
-    - 'Primary HPV testing or cotesting is recommended within one year from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy.yml
+++ b/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy.yml
@@ -51,4 +51,4 @@ results:
     date: '2022-06-02'
     group: 'Managing Histology (I.3)'
     details: 
-      - 'Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.'
+      - 'Primary HPV testing or cotesting in 1 year from date of most recent test is recommended.'

--- a/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy.yml
+++ b/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy.yml
@@ -51,4 +51,4 @@ results:
     date: '2022-06-02'
     group: 'Managing Histology (I.3)'
     details: 
-      - 'Primary HPV testing or cotesting in 1 year is recommended.'
+      - 'Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.'

--- a/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy2.yml
+++ b/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy2.yml
@@ -62,4 +62,4 @@ results:
     date: '2022-06-02'
     group: 'Managing Histology (I.3)'
     details: 
-      - 'Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.'
+      - 'Primary HPV testing or cotesting in 1 year from date of most recent test is recommended.'

--- a/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy2.yml
+++ b/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy2.yml
@@ -62,4 +62,4 @@ results:
     date: '2022-06-02'
     group: 'Managing Histology (I.3)'
     details: 
-      - 'Primary HPV testing or cotesting in 1 year is recommended.'
+      - 'Primary HPV testing or cotesting within 1 year from date of most recent test is recommended.'

--- a/test/ManagementHistologyResults/cases/I41HistologicLSILPrecededByHSILCytology.yml
+++ b/test/ManagementHistologyResults/cases/I41HistologicLSILPrecededByHSILCytology.yml
@@ -30,6 +30,6 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.1)'
     details: 
-      - 'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy within 1 year of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.'
+      - 'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy in 1 year from date of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.'
       - 'Observation is only acceptable when the initial colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and that the endocervical sampling, if collected, was less than CIN 2.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I41HistologicLSILPrecededByHSILCytology.yml
+++ b/test/ManagementHistologyResults/cases/I41HistologicLSILPrecededByHSILCytology.yml
@@ -30,6 +30,6 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.1)'
     details: 
-      - 'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy in 1 year, or review of the cytologic, histologic and colposcopic findings are acceptable.'
+      - 'Immediate diagnostic excisional procedure (unless the patient is pregnant), or observation with primary HPV testing or cotesting and colposcopy within 1 year of most recent histology, or review of the cytologic, histologic and colposcopic findings are acceptable.'
       - 'Observation is only acceptable when the initial colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and that the endocervical sampling, if collected, was less than CIN 2.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I42HistologicLSILPrecededByAscHCytology.yml
+++ b/test/ManagementHistologyResults/cases/I42HistologicLSILPrecededByAscHCytology.yml
@@ -30,6 +30,6 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.2)'
     details: 
-      - 'Observation with primary HPV testing or cotesting at 1 year is recommended if the colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and the endocervical sampling, if collected, was negative.'
+      - 'Observation with primary HPV testing or cotesting at 1 year after the colposcopy is recommended if the colposcopic examination fully visualized the squamocolumnar junction and the upper limit of any lesion, and the endocervical sampling, if collected, was negative.'
       - 'A diagnostic excisional procedure is not recommended.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
@@ -37,5 +37,5 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.3.1)'
     details: 
-      - 'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
+      - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
@@ -37,5 +37,5 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.3.1)'
     details: 
-      - 'Primary hrHPV testing or cotesting is recommended in 1 year.'
+      - 'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegativeFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegativeFollowUp.yml
@@ -45,5 +45,5 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.3.1)'
     details: 
-      - 'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
+      - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegativeFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegativeFollowUp.yml
@@ -45,5 +45,5 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.3.1)'
     details: 
-      - 'Primary hrHPV testing or cotesting is recommended in 1 year.'
+      - 'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/ManagementRareCytology/cases/G14AGCorAtypicalEndocervicalCells.yml
+++ b/test/ManagementRareCytology/cases/G14AGCorAtypicalEndocervicalCells.yml
@@ -25,7 +25,7 @@ results:
     date: '2022-05-01'
     group: 'Rare Cytology (G.1.4)'
     details:
-    - 'Cotesting at 1 and 2 years is recommended.'
+    - 'Cotesting at 1 and 2 years from date of most recent test is recommended.'
     - 'If both cotests are negative, repeat cotesting at 3 years is recommended.'
     - 'If any test is abnormal, then colposcopy is recommended.'
   WhichRarityMadeTheRecommendation: 1

--- a/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
@@ -54,5 +54,5 @@ results:
     date: '2024-05-01'
     group: 'Hysterectomy (K.4)'
     details:
-    - 'Primary hrHPV testing or cotesting is recommended every 3 years for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
+    - 'Primary hrHPV testing or cotesting is recommended every 3 years after date of most recent test for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
   WhichPopulationMadeTheRecommendation: 2

--- a/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
@@ -54,5 +54,7 @@ results:
     date: '2024-05-01'
     group: 'Hysterectomy (K.4)'
     details:
-    - 'Primary hrHPV testing or cotesting is recommended every 3 years after date of most recent test for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
+    - 'Primary hrHPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Testing should continue for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
+    - 'Future testing is recommended at 3-year intervals.'
   WhichPopulationMadeTheRecommendation: 2

--- a/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
+++ b/test/ManagementSpecialPopulations/cases/HysterectomyK42.yml
@@ -54,7 +54,7 @@ results:
     date: '2024-05-01'
     group: 'Hysterectomy (K.4)'
     details:
-    - 'Primary hrHPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary hrHPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'Testing should continue for 25 years after hysterectomy is performed for treatment of histologic HSIL, CIN 2, CIN 3 or AIS.'
     - 'Future testing is recommended at 3-year intervals.'
   WhichPopulationMadeTheRecommendation: 2

--- a/test/ManagementSpecialPopulations/cases/ImmunosuppressedK32.yml
+++ b/test/ManagementSpecialPopulations/cases/ImmunosuppressedK32.yml
@@ -30,5 +30,5 @@ results:
     date: '2021-11-01'
     group: 'Immunosuppressed (K.3)'
     details:
-    - 'Cervical cytology is recommended in 6 to 12 months in this immunocompromised patient.'
+    - 'Cervical cytology is recommended within 6 to 12 months from date of most recent test in this immunocompromised patient.'
   WhichPopulationMadeTheRecommendation: 3

--- a/test/ManagementSpecialPopulations/cases/ImmunosuppressedK32.yml
+++ b/test/ManagementSpecialPopulations/cases/ImmunosuppressedK32.yml
@@ -30,5 +30,5 @@ results:
     date: '2021-11-01'
     group: 'Immunosuppressed (K.3)'
     details:
-    - 'Cervical cytology is recommended within 6 to 12 months from date of most recent test in this immunocompromised patient.'
+    - 'Cervical cytology is recommended in 6 to 12 months from date of most recent test in this immunocompromised patient.'
   WhichPopulationMadeTheRecommendation: 3

--- a/test/ManagementSpecialPopulations/cases/Young11LowGradeCytology.yml
+++ b/test/ManagementSpecialPopulations/cases/Young11LowGradeCytology.yml
@@ -23,5 +23,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+    - 'Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young11LowGradeCytology.yml
+++ b/test/ManagementSpecialPopulations/cases/Young11LowGradeCytology.yml
@@ -23,5 +23,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+    - 'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young11LowGradeCytologyPosHPV.yml
+++ b/test/ManagementSpecialPopulations/cases/Young11LowGradeCytologyPosHPV.yml
@@ -35,5 +35,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+    - 'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young11LowGradeCytologyPosHPV.yml
+++ b/test/ManagementSpecialPopulations/cases/Young11LowGradeCytologyPosHPV.yml
@@ -35,5 +35,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+    - 'Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young14ASCUSHPVneg.yml
+++ b/test/ManagementSpecialPopulations/cases/Young14ASCUSHPVneg.yml
@@ -35,5 +35,5 @@ results:
     date: '2024-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Repeat testing is indicated within 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
+    - 'Repeat testing is indicated in 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young14ASCUSHPVneg.yml
+++ b/test/ManagementSpecialPopulations/cases/Young14ASCUSHPVneg.yml
@@ -35,5 +35,5 @@ results:
     date: '2024-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Repeat testing is indicated in 3 years. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
+    - 'Repeat testing is indicated within 3 years from date of most recent test. This should be cytology (Pap) if patient is < 25 and HPV testing or cotesting if patient is age 25 or older at the time of repeat testing.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young15aLSILBefore1YearFollowUp.yml
+++ b/test/ManagementSpecialPopulations/cases/Young15aLSILBefore1YearFollowUp.yml
@@ -29,5 +29,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+    - 'Cervical cytology is recommended in 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young15aLSILBefore1YearFollowUp.yml
+++ b/test/ManagementSpecialPopulations/cases/Young15aLSILBefore1YearFollowUp.yml
@@ -29,5 +29,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.1)'
     details:
-    - 'Cervical cytology is recommended in 1 year. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
+    - 'Cervical cytology is recommended within 1 year from date of most recent test. If the patient will be age 25 in 1 year, use HPV testing or cotesting.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
+++ b/test/ManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
@@ -30,7 +30,7 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.3)'
     details:
-    - 'Observation is recommended with colposcopy and cytology in 1 year.'
+    - 'Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.'
     - 'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*'
     - '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
+++ b/test/ManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
@@ -30,7 +30,7 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.3)'
     details:
-    - 'Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.'
+    - 'Observation is recommended with colposcopy and cytology in 1 year from date of most recent test.'
     - 'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*'
     - '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young31cAscHHistologyLessThanCin2.yml
+++ b/test/ManagementSpecialPopulations/cases/Young31cAscHHistologyLessThanCin2.yml
@@ -30,7 +30,7 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.3)'
     details:
-    - 'Observation is recommended with cytology within 1 year from date of most recent test.'
+    - 'Observation is recommended with cytology in 1 year from date of most recent test.'
     - 'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*'
     - '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young31cAscHHistologyLessThanCin2.yml
+++ b/test/ManagementSpecialPopulations/cases/Young31cAscHHistologyLessThanCin2.yml
@@ -30,7 +30,7 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.3)'
     details:
-    - 'Observation is recommended with cytology in 1 year.'
+    - 'Observation is recommended with cytology within 1 year from date of most recent test.'
     - 'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*'
     - '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young44HSILSurveillance.yml
+++ b/test/ManagementSpecialPopulations/cases/Young44HSILSurveillance.yml
@@ -31,5 +31,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.4)'
     details:
-    - 'Colposcopy and cervical cytology should be performed in 1 year.'
+    - 'Colposcopy and cervical cytology should be performed within 1 year from date of most recent test.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementSpecialPopulations/cases/Young44HSILSurveillance.yml
+++ b/test/ManagementSpecialPopulations/cases/Young44HSILSurveillance.yml
@@ -31,5 +31,5 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.4)'
     details:
-    - 'Colposcopy and cervical cytology should be performed within 1 year from date of most recent test.'
+    - 'Colposcopy and cervical cytology should be performed in 1 year from date of most recent test.'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv3YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv3YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
@@ -43,7 +43,7 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
@@ -43,6 +43,7 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv3YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv3YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
@@ -37,6 +37,7 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
@@ -37,7 +37,7 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenPositiveHpv1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NegativeHpvThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenPositiveHpv1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv3YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv3YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
@@ -30,6 +30,7 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
@@ -30,7 +30,7 @@ results:
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenNegativeHpv3YearFollowUp.yml
@@ -61,6 +61,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenNegativeHpv3YearFollowUp.yml
@@ -61,6 +61,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -56,6 +56,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -56,6 +56,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenNegativeHpv3YearFollowUp.yml
@@ -50,6 +50,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenNegativeHpv3YearFollowUp.yml
@@ -50,6 +50,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenPositiveHpv1YearFollowUp.yml
@@ -50,6 +50,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenPositiveHpv1YearFollowUp.yml
@@ -50,6 +50,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -47,7 +47,7 @@ results:
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -47,6 +47,7 @@ results:
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -47,6 +47,6 @@ results:
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenPositiveHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenPositiveHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv3YearFollowUp.yml
@@ -47,6 +47,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv3YearFollowUp.yml
@@ -47,6 +47,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpvNilmThenNegativeHpvNilm3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpvNilmThenNegativeHpvNilm3YearFollowUp.yml
@@ -60,6 +60,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpvNilmThenNegativeHpvNilm3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpvNilmThenNegativeHpvNilm3YearFollowUp.yml
@@ -60,6 +60,6 @@ results:
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenPositiveHpv1YearFollowUp.yml
@@ -47,6 +47,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenPositiveHpv1YearFollowUp.yml
@@ -47,6 +47,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/PositiveHpvNilmThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/PositiveHpvNilmThenNegativeHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable2/cases/PositiveHpvNilmThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/PositiveHpvNilmThenNegativeHpv1YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/ManagementTable3/cases/Cin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/Cin1Biopsy1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/Cin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/Cin1Biopsy1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/HpvPositiveThenCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/HpvPositiveThenCin1Biopsy1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/HpvPositiveThenCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/HpvPositiveThenCin1Biopsy1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
@@ -37,6 +37,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/LessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/LessThanCin1Biopsy1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/LessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/LessThanCin1Biopsy1YearFollowUp.yml
@@ -30,6 +30,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/LessThanCin1BiopsyExtendedHistory.yml
+++ b/test/ManagementTable3/cases/LessThanCin1BiopsyExtendedHistory.yml
@@ -62,6 +62,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable3/cases/LessThanCin1BiopsyExtendedHistory.yml
+++ b/test/ManagementTable3/cases/LessThanCin1BiopsyExtendedHistory.yml
@@ -62,6 +62,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/ManagementTable4/cases/AscusLsilNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -41,6 +41,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -41,6 +41,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
@@ -31,6 +31,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
@@ -31,6 +31,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegative3YearFollowUp.yml
@@ -34,6 +34,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegative3YearFollowUp.yml
@@ -34,6 +34,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -40,6 +40,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -40,6 +40,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvPositiveNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvPositiveNilm1YearFollowUp.yml
@@ -40,6 +40,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvPositiveNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvPositiveNilm1YearFollowUp.yml
@@ -40,6 +40,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
@@ -45,6 +45,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
@@ -45,6 +45,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -69,6 +69,6 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -69,7 +69,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -69,6 +69,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -48,6 +48,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -48,6 +48,6 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -48,7 +48,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegative1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegative1YearFollowUp.yml
@@ -32,6 +32,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegative1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegative1YearFollowUp.yml
@@ -32,6 +32,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeAscusLsil1YearFollowUp.yml
@@ -34,6 +34,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeAscusLsil1YearFollowUp.yml
@@ -34,6 +34,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilm1YearFollowUp.yml
@@ -38,6 +38,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilm1YearFollowUp.yml
@@ -38,6 +38,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -69,6 +69,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -69,6 +69,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -41,6 +41,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -41,6 +41,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativex2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativex2ThenHpvNegative3YearFollowUp.yml
@@ -48,6 +48,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativex2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativex2ThenHpvNegative3YearFollowUp.yml
@@ -48,6 +48,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
@@ -40,6 +40,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
@@ -40,6 +40,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegative3YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegative3YearFollowUp.yml
@@ -43,6 +43,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
@@ -54,6 +54,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
@@ -54,6 +54,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
@@ -58,6 +58,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
@@ -58,6 +58,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -58,6 +58,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -58,6 +58,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -58,6 +58,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -58,6 +58,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -78,6 +78,6 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -78,6 +78,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -78,7 +78,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -50,6 +50,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -50,6 +50,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -57,7 +57,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -57,6 +57,6 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -57,6 +57,7 @@ results:
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvPositiveNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvPositiveNilm1YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvPositiveNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvPositiveNilm1YearFollowUp.yml
@@ -49,6 +49,6 @@ results:
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
@@ -34,6 +34,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
@@ -34,6 +34,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilm1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilm1YearFollowUp.yml
@@ -53,6 +53,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilm1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilm1YearFollowUp.yml
@@ -53,6 +53,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
@@ -67,6 +67,6 @@ results:
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
@@ -67,6 +67,6 @@ results:
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegative1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegative1YearFollowUp.yml
@@ -39,6 +39,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegative1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegative1YearFollowUp.yml
@@ -39,6 +39,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -46,6 +46,6 @@ results:
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -46,6 +46,6 @@ results:
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/NoCIN2or3BeforeTreatmentThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/NoCIN2or3BeforeTreatmentThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
@@ -32,6 +32,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/ManagementTable5/cases/NoCIN2or3BeforeTreatmentThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/NoCIN2or3BeforeTreatmentThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
@@ -32,6 +32,6 @@ results:
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/WithObsManagementHistology/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
+++ b/test/WithObsManagementHistology/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
@@ -49,5 +49,5 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.3.1)'
     details: 
-      - 'Primary hrHPV testing or cotesting is recommended in 1 year.'
+      - 'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/WithObsManagementHistology/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
+++ b/test/WithObsManagementHistology/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
@@ -49,5 +49,5 @@ results:
     date: '2021-06-02'
     group: 'Managing Histology (I.4.3.1)'
     details: 
-      - 'Primary hrHPV testing or cotesting is recommended within 1 year from date of most recent test.'
+      - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'
   WhichRarityMadeTheRecommendation: 3

--- a/test/WithObsManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
+++ b/test/WithObsManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
@@ -39,7 +39,7 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.3)'
     details:
-    - 'Observation is recommended with colposcopy and cytology in 1 year.'
+    - 'Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.'
     - 'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*'
     - '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/WithObsManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
+++ b/test/WithObsManagementSpecialPopulations/cases/Young31bHSILHistologyLessThanCin2.yml
@@ -39,7 +39,7 @@ results:
     date: '2022-05-01'
     group: 'Younger Than 25 (K.1.3)'
     details:
-    - 'Observation is recommended with colposcopy and cytology within 1 year from date of most recent test.'
+    - 'Observation is recommended with colposcopy and cytology in 1 year from date of most recent test.'
     - 'Diagnostic excisional procedures are not recommended for patients younger than 25 with some exceptions.*'
     - '*Refer to ASCCP Consensus Guideline 2019 Section K.1'
   WhichPopulationMadeTheRecommendation: 5

--- a/test/WithObsManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -57,6 +57,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/WithObsManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -57,6 +57,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/WithObsManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
@@ -44,6 +44,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/WithObsManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
@@ -44,6 +44,6 @@ results:
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 1

--- a/test/WithObsManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -73,6 +73,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/WithObsManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -73,6 +73,6 @@ results:
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -53,6 +53,7 @@ results:
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -53,6 +53,6 @@ results:
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Routine screening at 5-year intervals using primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended at 5-year intervals from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -53,7 +53,7 @@ results:
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 5 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 5 years from date of most recent test.'
     - 'Future testing is recommended at 5-year intervals.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 3-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 2

--- a/test/WithObsManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/WithObsManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
@@ -45,6 +45,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/WithObsManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/WithObsManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
@@ -45,6 +45,6 @@ results:
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:
-    - 'Repeat testing in 1 year with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 1 year of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 3

--- a/test/WithObsManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/WithObsManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -76,6 +76,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/WithObsManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/WithObsManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -76,6 +76,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/WithObsManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/WithObsManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -75,6 +75,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/WithObsManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/WithObsManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -75,6 +75,6 @@ results:
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 4

--- a/test/WithObsManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/WithObsManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
@@ -91,6 +91,6 @@ results:
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Repeat testing in 3 years with primary HPV testing or cotesting is recommended.'
-    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals.'
+    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5

--- a/test/WithObsManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/WithObsManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
@@ -91,6 +91,6 @@ results:
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:
-    - 'Primary HPV testing or cotesting is recommended within 3 years of most recent test.'
+    - 'Primary HPV testing or cotesting is recommended in 3 years from date of most recent test.'
     - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 1-year intervals from date of most recent test.'
   WhichTableMadeTheRecommendation: 5


### PR DESCRIPTION
Update recommendation details when the time interval mentioned in the text is relative to the date of the last test (e.g. most recent cytology, histology, etc.) 

It can be confusing if the recommendation says "1 one year" of a test which occurred 15 months in the past. 
This change adopts the phrase "date of most recent test" to be the reference the time interval applies to. The date value shown is not changed (e.g. Collate.DateOfMostRecentReport + 1 years) but will now make it clear in the recommendation details that it is based on the most recent test, and that's why the date shown may be past.
