### PR TITLE
Specify time intervals in surveillance recommendation short texts

### DIFF
--- a/cql/ManageCommonAbnormality.cql
+++ b/cql/ManageCommonAbnormality.cql
@@ -568,7 +568,7 @@ define ErrataRecommendation:
       )
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 1-year follow-up',
         date: Collate.DateOfMostRecentReport + 1 years,
         details: {
           'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
@@ -725,7 +725,7 @@ define Action:
       TableRecommendation = '1-year follow-up'
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 1-year follow-up',
         date: Collate.DateOfMostRecentReport + 1 year,
         details: {
           OneYearSurveillanceRecommendationText,
@@ -737,7 +737,7 @@ define Action:
       TableRecommendation = '1-year follow-up'
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 1-year follow-up',
         date: Collate.DateOfMostRecentReport + 1 year,
         details: {
           OneYearSurveillanceRecommendationText,
@@ -749,7 +749,7 @@ define Action:
       TableRecommendation = '3-year follow-up'
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 3-year follow-up',
         date: Collate.DateOfMostRecentReport + 3 years,
         details: {
           ThreeYearSurveillanceRecommendationText,
@@ -761,7 +761,7 @@ define Action:
       TableRecommendation = '3-year follow-up'
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 3-year follow-up',
         date: Collate.DateOfMostRecentReport + 3 years,
         details: {
           ThreeYearSurveillanceRecommendationText,
@@ -773,7 +773,7 @@ define Action:
       TableRecommendation = '5-year follow-up'
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 5-year follow-up',
         date: Collate.DateOfMostRecentReport + 5 years,
         details: {
           FiveYearSurveillanceRecommendationText,
@@ -786,7 +786,7 @@ define Action:
       TableRecommendation = '5-year follow-up'
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 5-year follow-up',
         date: Collate.DateOfMostRecentReport + 5 years,
         details: {
           FiveYearSurveillanceRecommendationText,

--- a/cql/ManageCommonAbnormality.json
+++ b/cql/ManageCommonAbnormality.json
@@ -3114,7 +3114,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 1-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -3830,7 +3830,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 1-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -3900,7 +3900,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 1-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -3991,7 +3991,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 3-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -4061,7 +4061,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 3-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -4152,7 +4152,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 5-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -4225,7 +4225,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 5-year follow-up",
                            "type" : "Literal"
                         }
                      }, {

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -398,7 +398,7 @@ define RecommendationForRareCytology:
       HistologyInterpretedAsCin1OrNormal
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 1-year follow-up',
         date: Collate.DateOfMostRecentReport + 1 year,
         group: 'Rare Cytology (G.1.4)',
         details: {
@@ -1321,7 +1321,7 @@ define RecommendationForHistologyResults:
       not (HasPositiveSurveillanceAfterSecondNegativeHsilSurveillance)
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 3-year follow-up',
         date: Today() + 3 years,
         group: 'Managing Histology (I.3)',
         details: {
@@ -1337,7 +1337,7 @@ define RecommendationForHistologyResults:
       // TODO: Investigate whether RecentlyRespondedYesToFuturePregnancyConcernsQuestion needs to be checked for I3.3, 13.4, and I3.5
     ) then
       {
-        short: 'Surveillance',
+        short: 'Surveillance 1-year follow-up',
         date: Today() + 1 year,
         group: 'Managing Histology (I.3)',
         details: {

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -3314,7 +3314,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 1-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -10302,7 +10302,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 3-year follow-up",
                            "type" : "Literal"
                         }
                      }, {
@@ -10436,7 +10436,7 @@
                         "name" : "short",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance",
+                           "value" : "Surveillance 1-year follow-up",
                            "type" : "Literal"
                         }
                      }, {

--- a/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegative.yml
+++ b/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegative.yml
@@ -38,7 +38,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:

--- a/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegativeNilm.yml
+++ b/test/ManagementErrata/cases/3.2.3-AscusHpvPositiveCotestFollowedByHpvNegativeNilm.yml
@@ -46,7 +46,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:

--- a/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegative.yml
+++ b/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegative.yml
@@ -31,7 +31,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:

--- a/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegativeNilm.yml
+++ b/test/ManagementErrata/cases/3.2.3-LsilAloneFollowedByHpvNegativeNilm.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: '2023 JLGTD Addendum to the 2019 ASCCP Guidelines'
     details:

--- a/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy.yml
+++ b/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy.yml
@@ -47,7 +47,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-06-02'
     group: 'Managing Histology (I.3)'
     details: 

--- a/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy2.yml
+++ b/test/ManagementHistologyResults/cases/I33HistologicHSILNegSurv1YearConcernedAboutFuturePregnancy2.yml
@@ -58,7 +58,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-06-02'
     group: 'Managing Histology (I.3)'
     details: 

--- a/test/ManagementHistologyResults/cases/I34HistologicHSILNegSurv3YearConcernedAboutFuturePregnancy2.yml
+++ b/test/ManagementHistologyResults/cases/I34HistologicHSILNegSurv3YearConcernedAboutFuturePregnancy2.yml
@@ -135,7 +135,7 @@ data:
   
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-06-02'
     group: 'Managing Histology (I.3)'
     details: 

--- a/test/ManagementHistologyResults/cases/I34HistologicHSILNegSurv3YearsConcernedAboutFuturePregnancy.yml
+++ b/test/ManagementHistologyResults/cases/I34HistologicHSILNegSurv3YearsConcernedAboutFuturePregnancy.yml
@@ -119,7 +119,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-06-02'
     group: 'Managing Histology (I.3)'
     details: 

--- a/test/ManagementRareCytology/cases/G14AGCorAtypicalEndocervicalCells.yml
+++ b/test/ManagementRareCytology/cases/G14AGCorAtypicalEndocervicalCells.yml
@@ -21,7 +21,7 @@ data:
 
 results:
   Recommendation: 
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Rare Cytology (G.1.4)'
     details:

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv3YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenNegativeHpv5YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv1YearFollowUp.yml
@@ -33,7 +33,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv3YearFollowUp.yml
@@ -33,7 +33,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenNegativeHpv5YearFollowUp.yml
@@ -33,7 +33,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NegativeHpvThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NegativeHpvThenPositiveHpv1YearFollowUp.yml
@@ -33,7 +33,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv1YearFollowUp.yml
@@ -26,7 +26,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv3YearFollowUp.yml
@@ -26,7 +26,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryNegativeHpv5YearFollowUp.yml
@@ -26,7 +26,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
@@ -26,7 +26,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenNegativeHpv3YearFollowUp.yml
@@ -57,7 +57,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -52,7 +52,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenNegativeHpv3YearFollowUp.yml
@@ -46,7 +46,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/HpvPositiveNilmThenNegativeHpvThenPositiveHpv1YearFollowUp.yml
@@ -46,7 +46,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv1YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -43,7 +43,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvAscusThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvAscusThenPositiveHpv1YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv1YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpv3YearFollowUp.yml
@@ -43,7 +43,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpvNilmThenNegativeHpvNilm3YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenNegativeHpvNilmThenNegativeHpvNilm3YearFollowUp.yml
@@ -56,7 +56,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/NegativeHpvLsilThenPositiveHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/NegativeHpvLsilThenPositiveHpv1YearFollowUp.yml
@@ -43,7 +43,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable2/cases/PositiveHpvNilmThenNegativeHpv1YearFollowUp.yml
+++ b/test/ManagementTable2/cases/PositiveHpvNilmThenNegativeHpv1YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/ManagementTable3/cases/Cin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/Cin1Biopsy1YearFollowUp.yml
@@ -26,7 +26,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:

--- a/test/ManagementTable3/cases/HpvPositiveThenCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/HpvPositiveThenCin1Biopsy1YearFollowUp.yml
@@ -33,7 +33,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:

--- a/test/ManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
@@ -33,7 +33,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:

--- a/test/ManagementTable3/cases/LessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/ManagementTable3/cases/LessThanCin1Biopsy1YearFollowUp.yml
@@ -26,7 +26,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:

--- a/test/ManagementTable3/cases/LessThanCin1BiopsyExtendedHistory.yml
+++ b/test/ManagementTable3/cases/LessThanCin1BiopsyExtendedHistory.yml
@@ -58,7 +58,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:

--- a/test/ManagementTable4/cases/AscusLsilNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -37,7 +37,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
@@ -27,7 +27,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegative3YearFollowUp.yml
@@ -30,7 +30,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -36,7 +36,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvPositiveNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvPositiveNilm1YearFollowUp.yml
@@ -36,7 +36,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
@@ -41,7 +41,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -65,7 +65,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/AscusOrLsilThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -44,7 +44,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegative1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegative1YearFollowUp.yml
@@ -28,7 +28,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeAscusLsil1YearFollowUp.yml
@@ -30,7 +30,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilm1YearFollowUp.yml
@@ -34,7 +34,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -65,7 +65,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -37,7 +37,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativex2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HighGradePapThenLessThanCin2ThenHpvNegativex2ThenHpvNegative3YearFollowUp.yml
@@ -44,7 +44,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenAscusLsil1YearFollowUp.yml
@@ -36,7 +36,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegative3YearFollowUp.yml
@@ -39,7 +39,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeAscusOrLsil1YearFollowUp.yml
@@ -50,7 +50,7 @@ data:
   
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeAscusOrLsilThenHpvNegativeNilm3YearFollowUp.yml
@@ -54,7 +54,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -54,7 +54,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvPositiveNilmAscusOrLsil1YearFollowUp.yml
@@ -54,7 +54,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmx2ThenHpvNegativeNilm5YearFollowUp.yml
@@ -74,7 +74,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -46,7 +46,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativex2ThenHpvNegative5YearFollowUp.yml
@@ -53,7 +53,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvPositiveNilm1YearFollowUp.yml
+++ b/test/ManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvPositiveNilm1YearFollowUp.yml
@@ -45,7 +45,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
@@ -30,7 +30,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilm1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilm1YearFollowUp.yml
@@ -49,7 +49,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
@@ -63,7 +63,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegative1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegative1YearFollowUp.yml
@@ -35,7 +35,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegativeThenHpvNegative3YearFollowUp.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvNegativeThenHpvNegativeThenHpvNegative3YearFollowUp.yml
@@ -42,7 +42,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:

--- a/test/ManagementTable5/cases/NoCIN2or3BeforeTreatmentThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
+++ b/test/ManagementTable5/cases/NoCIN2or3BeforeTreatmentThenHpvNegativeNilmAscusLsilOrAll1YearFollowUp.yml
@@ -28,7 +28,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Post Treatment (Table 5)'
     details:

--- a/test/WithObsManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable1/cases/NegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -53,7 +53,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/WithObsManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable1/cases/NoHistoryPositiveHpv1YearFollowUp.yml
@@ -40,7 +40,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'General Screening (Table 1)'
     details:

--- a/test/WithObsManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/HpvPositiveNilmThenNegativeCotestThenPositiveHpv1YearFollowUp.yml
@@ -69,7 +69,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
+++ b/test/WithObsManagementTable2/cases/NegativeHpvAscusThenNegativeHpv5YearFollowUp.yml
@@ -49,7 +49,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 5-year follow-up'
     date: '2026-05-01'
     group: 'Surveillance (Table 2)'
     details:

--- a/test/WithObsManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
+++ b/test/WithObsManagementTable3/cases/HpvPositiveThenLessThanCin1Biopsy1YearFollowUp.yml
@@ -41,7 +41,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 1-year follow-up'
     date: '2022-05-14'
     group: 'Colposcopy Results (Table 3)'
     details:

--- a/test/WithObsManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/WithObsManagementTable4/cases/AscusLsilThenLessThenCin2ThenHpvNegativeNilm3YearFollowUp.yml
@@ -72,7 +72,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/WithObsManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
+++ b/test/WithObsManagementTable4/cases/HpvPositiveNilmThenLessThanCin2ThenHpvNegativeNilmThenHpvNegativeNilmAscusOrLsil3YearFollowUp.yml
@@ -71,7 +71,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Colposcopy (Table 4)'
     details:

--- a/test/WithObsManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
+++ b/test/WithObsManagementTable5/cases/CIN2or3ThenHpvNegativeNilmThenHpvNegativeNilmThenHpvNegativeNilm3YearFollowUp.yml
@@ -87,7 +87,7 @@ data:
 
 results:
   Recommendation:
-    short: 'Surveillance'
+    short: 'Surveillance 3-year follow-up'
     date: '2024-05-01'
     group: 'Post Treatment (Table 5)'
     details:


### PR DESCRIPTION
Addresses [CCSMCDS-204](https://jira.mitre.org/browse/CCSMCDS-204). It was requested that our "short" recommendation text statements of "Surveillance" be updated to specify the date at which a patient is due back for testing, since the term surveillance may be confusing to a clinician in this context.