### PR TITLE
fix ccsmcds-212 to use new vsac codes for cervical cancer

### DIFF
--- a/test/ManagementSpecialPopulations/cases/resources.yml
+++ b/test/ManagementSpecialPopulations/cases/resources.yml
@@ -540,7 +540,31 @@ reusable_resources:
     code: LOINC#65753-6 Cervix Pathology biopsy report
     status: final
     conclusionCode:
+    - SNOMEDCT#1237481003 Metastatic carcinoma to cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1237492002 Metastatic carcinoma to endocervix (disorder)
+    effectiveDateTime: 2021-05-01    
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1237493007 Metastatic carcinoma to exocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
     - SNOMEDCT#123842006 Endocervical adenocarcinoma (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1254689008 Metastatic adenoid cystic carcinoma to cervix uteri (disorder)
     effectiveDateTime: 2021-05-01
   - resourceType: DiagnosticReport
     code: LOINC#65753-6 Cervix Pathology biopsy report
@@ -571,6 +595,48 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#1259516001 Primary carcinoma of exocervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1264117000 Metastatic adenosquamous carcinoma to cervix (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1268536009 Primary adenoid basal carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1268537000 Primary adenoid cystic carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1268631009 Primary glassy cell carcinoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1268638003 Primary adenosarcoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1268639006 Primary carcinosarcoma of cervix uteri (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#1268959008 Primary primitive neuroectodermal tumor of cervix uteri (disorder)
     effectiveDateTime: 2021-05-01
   - resourceType: DiagnosticReport
     code: LOINC#65753-6 Cervix Pathology biopsy report
@@ -666,12 +732,6 @@ reusable_resources:
     code: LOINC#65753-6 Cervix Pathology biopsy report
     status: final
     conclusionCode:
-    - SNOMEDCT#369459003 Malignant tumor involving rectum by separate metastasis from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
     - SNOMEDCT#369473007 Malignant tumor involving bladder by direct extension from uterine cervix (disorder)
     effectiveDateTime: 2021-05-01
   - resourceType: DiagnosticReport
@@ -702,18 +762,6 @@ reusable_resources:
     code: LOINC#65753-6 Cervix Pathology biopsy report
     status: final
     conclusionCode:
-    - SNOMEDCT#369500009 Malignant tumor involving uterine cervix by separate metastasis from fallopian tube (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
-    - SNOMEDCT#369501008 Malignant tumor involving uterine cervix by separate metastasis from ovary (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
     - SNOMEDCT#369518007 Malignant tumor involving left fallopian tube by direct extension from uterine cervix (disorder)
     effectiveDateTime: 2021-05-01
   - resourceType: DiagnosticReport
@@ -726,55 +774,13 @@ reusable_resources:
     code: LOINC#65753-6 Cervix Pathology biopsy report
     status: final
     conclusionCode:
-    - SNOMEDCT#369556008 Malignant tumor involving right fallopian tube by separate metastasis from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
-    - SNOMEDCT#369571007 Malignant tumor involving right ovary by separate metastasis from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
-    - SNOMEDCT#369574004 Malignant tumor involving uterine cervix by separate metastasis from vagina (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
-    - SNOMEDCT#369577006 Malignant tumor involving uterine corpus by separate metastasis from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
     - SNOMEDCT#369580007 Malignant tumor involving vagina by direct extension from uterine cervix (disorder)
     effectiveDateTime: 2021-05-01
   - resourceType: DiagnosticReport
     code: LOINC#65753-6 Cervix Pathology biopsy report
     status: final
     conclusionCode:
-    - SNOMEDCT#369585002 Malignant tumor involving vagina by separate metastasis from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
-    - SNOMEDCT#369591000 Malignant tumor involving vulva by separate metastasis from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
     - SNOMEDCT#369599003 Malignant tumor involving an organ by direct extension from uterine cervix (disorder)
-    effectiveDateTime: 2021-05-01
-  - resourceType: DiagnosticReport
-    code: LOINC#65753-6 Cervix Pathology biopsy report
-    status: final
-    conclusionCode:
-    - SNOMEDCT#369610009 Malignant tumor involving left fallopian tube by separate metastasis from uterine cervix (disorder)
     effectiveDateTime: 2021-05-01
   - resourceType: DiagnosticReport
     code: LOINC#65753-6 Cervix Pathology biopsy report


### PR DESCRIPTION
VSAC updated the codes used in the Cervical Cancer value set (2.16.840.1.113762.1.4.1032.244.xml)
The tests for cervical cancer in ManagementSpecialPopulation iterate over an entry in the resources.yml file that enumerated all the codes in .244.xml. Since this file has been updated with some new codes added and some old codes removed, several of the test cases were failing.
This updates the resources.yml file to use the latest SNOMED codes in 244.xml