### PR TITLE
Bump version to 0.4.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm-cds-with-tests",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm-cds-with-tests",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-testing": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm-cds-with-tests",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "This repository contains clinical decision support (CDS) which provides recommendations for cervical cancer screening and management (CCSM).",
   "exports": {
     "./fhir/ActivityDefinition/*.js": "./dist/fhir/ActivityDefinition/*.js",


### PR DESCRIPTION
# ccsm-cds-with-tests version 0.4.19
- https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/141
- https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/147
- https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/148
- https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/149
- https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/150