### PR TITLE
Add hrHPV followed by negative histology test cases

### DIFF
--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -662,7 +662,6 @@ define HasNoCytologyInterpretedAsAgcAfterCytologyInterpretedAsAscH:
 define RecommendationForExceptionsToColposcopyThreshold:
   case
     when (
-      Collate.HasNoBiopsyOrTreatmentAfterDate(Collate.MostRecentCytologyCotest.date) and
       LastKnownCytologyInterpretedAsAscHInPast10Years is not null and
       Collate.HasNoBiopsyOrTreatmentAfterDate(LastKnownCytologyInterpretedAsAscHInPast10Years.date) and
       HasNoCytologyInterpretedAsHsilAfterDate(LastKnownCytologyInterpretedAsAscHInPast10Years.date) and

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -659,9 +659,27 @@ define HasNoCytologyInterpretedAsAgcAfterCytologyInterpretedAsAscH:
   LastKnownCytologyInterpretedAsAgc.date is null or
   not (LastKnownCytologyInterpretedAsAgc.date occurs after LastKnownCytologyInterpretedAsAscHInPast10Years.date)
 
+define RecommendationForPreviousColposcopy:
+  case
+    when (
+      Collate.HasNoBiopsyOrTreatmentAfterDate(Collate.MostRecentCytologyCotest.date)
+    ) then
+      {
+        short: 'Surveillance 1-year follow-up',
+        date: Today(),
+        group: '?',
+        details: {
+          '???'
+        }
+      }
+    else
+      null
+  end
+
 define RecommendationForExceptionsToColposcopyThreshold:
   case
     when (
+      Collate.HasNoBiopsyOrTreatmentAfterDate(Collate.MostRecentCytologyCotest.date) and
       LastKnownCytologyInterpretedAsAscHInPast10Years is not null and
       Collate.HasNoBiopsyOrTreatmentAfterDate(LastKnownCytologyInterpretedAsAscHInPast10Years.date) and
       HasNoCytologyInterpretedAsHsilAfterDate(LastKnownCytologyInterpretedAsAscHInPast10Years.date) and
@@ -676,6 +694,7 @@ define RecommendationForExceptionsToColposcopyThreshold:
         }
       }
     when (
+      Collate.HasNoBiopsyOrTreatmentAfterDate(Collate.MostRecentCytologyCotest.date) and
       MostRecentCytologyReportWasWithinPastFiveYears and
       PositiveHpv16or18Cotest and
       CytologyInterpretedAsNilm and
@@ -690,6 +709,7 @@ define RecommendationForExceptionsToColposcopyThreshold:
         }
       }
     when (
+      Collate.HasNoBiopsyOrTreatmentAfterDate(Collate.MostRecentCytologyCotest.date) and
       MostRecentCytologyReportWasWithinPastFiveYears and
       CytologyUnsatisfactory and
       TwoMostRecentCytologyReportsWithin5yearsApart and
@@ -2023,6 +2043,7 @@ define Recommendation:
     RecommendationForSurveillanceAfterAbnormalities,
     RecommendationForHistologyResults,
     RecommendationForExceptionsToColposcopyThreshold,
+    RecommendationForPreviousColposcopy,
     RecommendationForRareCytology
   )
 

--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -659,23 +659,6 @@ define HasNoCytologyInterpretedAsAgcAfterCytologyInterpretedAsAscH:
   LastKnownCytologyInterpretedAsAgc.date is null or
   not (LastKnownCytologyInterpretedAsAgc.date occurs after LastKnownCytologyInterpretedAsAscHInPast10Years.date)
 
-define RecommendationForPreviousColposcopy:
-  case
-    when (
-      Collate.HasNoBiopsyOrTreatmentAfterDate(Collate.MostRecentCytologyCotest.date)
-    ) then
-      {
-        short: 'Surveillance 1-year follow-up',
-        date: Today(),
-        group: '?',
-        details: {
-          '???'
-        }
-      }
-    else
-      null
-  end
-
 define RecommendationForExceptionsToColposcopyThreshold:
   case
     when (
@@ -2033,6 +2016,20 @@ define RecommendationForSurveillanceAfterAbnormalities:
           'Continued surveillance with HPV testing or cotesting at 3-year intervals is recommended and may continue as long as the patient is in reasonably good health.'
         }
       }
+    when ( // J.4 - special case not handled by Table3
+      HistologyInterpretedAsCin1OrNormal and
+      Collate.MostRecentHpvReport.date included in Collate.MostRecentBiopsyReferralPeriod and
+      Collate.MostRecentHpvResult in {'HPV16+','HPV16-, HPV18+','HPV-positive'} and
+      Collate.ReferringCytologyResult = 'NILM'
+    ) then
+      {
+        short: 'Surveillance 1-year follow-up',
+        group: 'Management Surveillance (J.4)',
+        date: Collate.DateOfMostRecentReport + 1 years,
+        details: {
+          'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
+        }
+      }
     else
       null
   end
@@ -2043,7 +2040,6 @@ define Recommendation:
     RecommendationForSurveillanceAfterAbnormalities,
     RecommendationForHistologyResults,
     RecommendationForExceptionsToColposcopyThreshold,
-    RecommendationForPreviousColposcopy,
     RecommendationForRareCytology
   )
 

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -4722,30 +4722,14 @@
                         "operand" : [ {
                            "type" : "And",
                            "operand" : [ {
-                              "type" : "And",
-                              "operand" : [ {
-                                 "name" : "HasNoBiopsyOrTreatmentAfterDate",
-                                 "libraryName" : "Collate",
-                                 "type" : "FunctionRef",
-                                 "operand" : [ {
-                                    "path" : "date",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "MostRecentCytologyCotest",
-                                       "libraryName" : "Collate",
-                                       "type" : "ExpressionRef"
-                                    }
-                                 } ]
-                              }, {
-                                 "type" : "Not",
+                              "type" : "Not",
+                              "operand" : {
+                                 "type" : "IsNull",
                                  "operand" : {
-                                    "type" : "IsNull",
-                                    "operand" : {
-                                       "name" : "LastKnownCytologyInterpretedAsAscHInPast10Years",
-                                       "type" : "ExpressionRef"
-                                    }
+                                    "name" : "LastKnownCytologyInterpretedAsAscHInPast10Years",
+                                    "type" : "ExpressionRef"
                                  }
-                              } ]
+                              }
                            }, {
                               "name" : "HasNoBiopsyOrTreatmentAfterDate",
                               "libraryName" : "Collate",

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -4709,99 +4709,6 @@
                } ]
             }
          }, {
-            "name" : "RecommendationForPreviousColposcopy",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "type" : "Case",
-               "caseItem" : [ {
-                  "when" : {
-                     "name" : "HasNoBiopsyOrTreatmentAfterDate",
-                     "libraryName" : "Collate",
-                     "type" : "FunctionRef",
-                     "operand" : [ {
-                        "path" : "date",
-                        "type" : "Property",
-                        "source" : {
-                           "name" : "MostRecentCytologyCotest",
-                           "libraryName" : "Collate",
-                           "type" : "ExpressionRef"
-                        }
-                     } ]
-                  },
-                  "then" : {
-                     "type" : "Tuple",
-                     "element" : [ {
-                        "name" : "short",
-                        "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Surveillance 1-year follow-up",
-                           "type" : "Literal"
-                        }
-                     }, {
-                        "name" : "date",
-                        "value" : {
-                           "type" : "Today"
-                        }
-                     }, {
-                        "name" : "group",
-                        "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "?",
-                           "type" : "Literal"
-                        }
-                     }, {
-                        "name" : "details",
-                        "value" : {
-                           "type" : "List",
-                           "element" : [ {
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "???",
-                              "type" : "Literal"
-                           } ]
-                        }
-                     } ]
-                  }
-               } ],
-               "else" : {
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "type" : "TupleTypeSpecifier",
-                     "element" : [ {
-                        "name" : "short",
-                        "elementType" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}String",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }, {
-                        "name" : "date",
-                        "elementType" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Date",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }, {
-                        "name" : "group",
-                        "elementType" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}String",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }, {
-                        "name" : "details",
-                        "elementType" : {
-                           "type" : "ListTypeSpecifier",
-                           "elementType" : {
-                              "name" : "{urn:hl7-org:elm-types:r1}String",
-                              "type" : "NamedTypeSpecifier"
-                           }
-                        }
-                     } ]
-                  }
-               }
-            }
-         }, {
             "name" : "RecommendationForExceptionsToColposcopyThreshold",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -14013,6 +13920,110 @@
                         }
                      } ]
                   }
+               }, {
+                  "when" : {
+                     "type" : "And",
+                     "operand" : [ {
+                        "type" : "And",
+                        "operand" : [ {
+                           "type" : "And",
+                           "operand" : [ {
+                              "name" : "HistologyInterpretedAsCin1OrNormal",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "type" : "In",
+                              "operand" : [ {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentHpvReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }, {
+                                 "name" : "MostRecentBiopsyReferralPeriod",
+                                 "libraryName" : "Collate",
+                                 "type" : "ExpressionRef"
+                              } ]
+                           } ]
+                        }, {
+                           "type" : "In",
+                           "operand" : [ {
+                              "name" : "MostRecentHpvResult",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "type" : "List",
+                              "element" : [ {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                                 "value" : "HPV16+",
+                                 "type" : "Literal"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                                 "value" : "HPV16-, HPV18+",
+                                 "type" : "Literal"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                                 "value" : "HPV-positive",
+                                 "type" : "Literal"
+                              } ]
+                           } ]
+                        } ]
+                     }, {
+                        "type" : "Equal",
+                        "operand" : [ {
+                           "name" : "ReferringCytologyResult",
+                           "libraryName" : "Collate",
+                           "type" : "ExpressionRef"
+                        }, {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "NILM",
+                           "type" : "Literal"
+                        } ]
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Surveillance 1-year follow-up",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Management Surveillance (J.4)",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "name" : "DateOfMostRecentReport",
+                              "libraryName" : "Collate",
+                              "type" : "ExpressionRef"
+                           }, {
+                              "value" : 1,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
                } ],
                "else" : {
                   "type" : "As",
@@ -14074,6 +14085,101 @@
                   "name" : "RecommendationForRareCytology",
                   "type" : "ExpressionRef"
                } ]
+            }
+         }, {
+            "name" : "WhichRarityMadeTheRecommendation",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Case",
+               "caseItem" : [ {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "RecommendationForAisHistologyResults",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "3",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "RecommendationForSurveillanceAfterAbnormalities",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "4",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "RecommendationForHistologyResults",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "3",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "RecommendationForExceptionsToColposcopyThreshold",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "when" : {
+                     "type" : "Not",
+                     "operand" : {
+                        "type" : "IsNull",
+                        "operand" : {
+                           "name" : "RecommendationForRareCytology",
+                           "type" : "ExpressionRef"
+                        }
+                     }
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  }
+               } ],
+               "else" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  }
+               }
             }
          }, {
             "name" : "Errors",

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -4709,6 +4709,99 @@
                } ]
             }
          }, {
+            "name" : "RecommendationForPreviousColposcopy",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Case",
+               "caseItem" : [ {
+                  "when" : {
+                     "name" : "HasNoBiopsyOrTreatmentAfterDate",
+                     "libraryName" : "Collate",
+                     "type" : "FunctionRef",
+                     "operand" : [ {
+                        "path" : "date",
+                        "type" : "Property",
+                        "source" : {
+                           "name" : "MostRecentCytologyCotest",
+                           "libraryName" : "Collate",
+                           "type" : "ExpressionRef"
+                        }
+                     } ]
+                  },
+                  "then" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "short",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Surveillance 1-year follow-up",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "date",
+                        "value" : {
+                           "type" : "Today"
+                        }
+                     }, {
+                        "name" : "group",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "?",
+                           "type" : "Literal"
+                        }
+                     }, {
+                        "name" : "details",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "???",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     } ]
+                  }
+               } ],
+               "else" : {
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "type" : "TupleTypeSpecifier",
+                     "element" : [ {
+                        "name" : "short",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}String",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "date",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Date",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "group",
+                        "elementType" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}String",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "name" : "details",
+                        "elementType" : {
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}String",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
             "name" : "RecommendationForExceptionsToColposcopyThreshold",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -4722,14 +4815,30 @@
                         "operand" : [ {
                            "type" : "And",
                            "operand" : [ {
-                              "type" : "Not",
-                              "operand" : {
-                                 "type" : "IsNull",
+                              "type" : "And",
+                              "operand" : [ {
+                                 "name" : "HasNoBiopsyOrTreatmentAfterDate",
+                                 "libraryName" : "Collate",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentCytologyCotest",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 } ]
+                              }, {
+                                 "type" : "Not",
                                  "operand" : {
-                                    "name" : "LastKnownCytologyInterpretedAsAscHInPast10Years",
-                                    "type" : "ExpressionRef"
+                                    "type" : "IsNull",
+                                    "operand" : {
+                                       "name" : "LastKnownCytologyInterpretedAsAscHInPast10Years",
+                                       "type" : "ExpressionRef"
+                                    }
                                  }
-                              }
+                              } ]
                            }, {
                               "name" : "HasNoBiopsyOrTreatmentAfterDate",
                               "libraryName" : "Collate",
@@ -4801,8 +4910,24 @@
                         "operand" : [ {
                            "type" : "And",
                            "operand" : [ {
-                              "name" : "MostRecentCytologyReportWasWithinPastFiveYears",
-                              "type" : "ExpressionRef"
+                              "type" : "And",
+                              "operand" : [ {
+                                 "name" : "HasNoBiopsyOrTreatmentAfterDate",
+                                 "libraryName" : "Collate",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentCytologyCotest",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 } ]
+                              }, {
+                                 "name" : "MostRecentCytologyReportWasWithinPastFiveYears",
+                                 "type" : "ExpressionRef"
+                              } ]
                            }, {
                               "name" : "PositiveHpv16or18Cotest",
                               "type" : "ExpressionRef"
@@ -4872,8 +4997,24 @@
                         "operand" : [ {
                            "type" : "And",
                            "operand" : [ {
-                              "name" : "MostRecentCytologyReportWasWithinPastFiveYears",
-                              "type" : "ExpressionRef"
+                              "type" : "And",
+                              "operand" : [ {
+                                 "name" : "HasNoBiopsyOrTreatmentAfterDate",
+                                 "libraryName" : "Collate",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "path" : "date",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "MostRecentCytologyCotest",
+                                       "libraryName" : "Collate",
+                                       "type" : "ExpressionRef"
+                                    }
+                                 } ]
+                              }, {
+                                 "name" : "MostRecentCytologyReportWasWithinPastFiveYears",
+                                 "type" : "ExpressionRef"
+                              } ]
                            }, {
                               "name" : "CytologyUnsatisfactory",
                               "type" : "ExpressionRef"
@@ -13933,101 +14074,6 @@
                   "name" : "RecommendationForRareCytology",
                   "type" : "ExpressionRef"
                } ]
-            }
-         }, {
-            "name" : "WhichRarityMadeTheRecommendation",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "expression" : {
-               "type" : "Case",
-               "caseItem" : [ {
-                  "when" : {
-                     "type" : "Not",
-                     "operand" : {
-                        "type" : "IsNull",
-                        "operand" : {
-                           "name" : "RecommendationForAisHistologyResults",
-                           "type" : "ExpressionRef"
-                        }
-                     }
-                  },
-                  "then" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "3",
-                     "type" : "Literal"
-                  }
-               }, {
-                  "when" : {
-                     "type" : "Not",
-                     "operand" : {
-                        "type" : "IsNull",
-                        "operand" : {
-                           "name" : "RecommendationForSurveillanceAfterAbnormalities",
-                           "type" : "ExpressionRef"
-                        }
-                     }
-                  },
-                  "then" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "4",
-                     "type" : "Literal"
-                  }
-               }, {
-                  "when" : {
-                     "type" : "Not",
-                     "operand" : {
-                        "type" : "IsNull",
-                        "operand" : {
-                           "name" : "RecommendationForHistologyResults",
-                           "type" : "ExpressionRef"
-                        }
-                     }
-                  },
-                  "then" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "3",
-                     "type" : "Literal"
-                  }
-               }, {
-                  "when" : {
-                     "type" : "Not",
-                     "operand" : {
-                        "type" : "IsNull",
-                        "operand" : {
-                           "name" : "RecommendationForExceptionsToColposcopyThreshold",
-                           "type" : "ExpressionRef"
-                        }
-                     }
-                  },
-                  "then" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "2",
-                     "type" : "Literal"
-                  }
-               }, {
-                  "when" : {
-                     "type" : "Not",
-                     "operand" : {
-                        "type" : "IsNull",
-                        "operand" : {
-                           "name" : "RecommendationForRareCytology",
-                           "type" : "ExpressionRef"
-                        }
-                     }
-                  },
-                  "then" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "1",
-                     "type" : "Literal"
-                  }
-               } ],
-               "else" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  }
-               }
             }
          }, {
             "name" : "Errors",

--- a/test/ManagementHpvPanelTesting/cases/Hpv16.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv16.yml
@@ -41,3 +41,9 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: true
+  Recommendation: 
+    short: 'Colposcopy'
+    date: '2021-06-02'
+    group: 'Exception to Colposcopy Threshold (H.2)'
+    details:
+    - 'Colposcopy is recommended for all patients with HPV 16 or 18.'

--- a/test/ManagementHpvPanelTesting/cases/Hpv16AndUntyped.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv16AndUntyped.yml
@@ -48,3 +48,9 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: true
+  Recommendation: 
+    short: 'Colposcopy'
+    date: '2021-06-02'
+    group: 'Exception to Colposcopy Threshold (H.2)'
+    details:
+    - 'Colposcopy is recommended for all patients with HPV 16 or 18.'

--- a/test/ManagementHpvPanelTesting/cases/Hpv16AndUntypedNegative.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv16AndUntypedNegative.yml
@@ -48,3 +48,4 @@ results:
   NegativeOrUnknownHpvCotest: true
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: false
+  Recommendation: null

--- a/test/ManagementHpvPanelTesting/cases/Hpv16NegativeAndUntypedPositive.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv16NegativeAndUntypedPositive.yml
@@ -48,4 +48,3 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: true
   PositiveHpv16or18Cotest: false
-

--- a/test/ManagementHpvPanelTesting/cases/Hpv16NegativeAndUntypedPositive.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv16NegativeAndUntypedPositive.yml
@@ -48,3 +48,6 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: true
   PositiveHpv16or18Cotest: false
+  Recommendation: null
+  WhichRarityMadeTheRecommendation: null
+  MostRecentSurveillanceTestNegative: false

--- a/test/ManagementHpvPanelTesting/cases/Hpv18.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv18.yml
@@ -41,4 +41,10 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: true
+  Recommendation: 
+    short: 'Colposcopy'
+    date: '2021-06-02'
+    group: 'Exception to Colposcopy Threshold (H.2)'
+    details:
+    - 'Colposcopy is recommended for all patients with HPV 16 or 18.'
 

--- a/test/ManagementHpvPanelTesting/cases/Hpv18AndUntyped.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv18AndUntyped.yml
@@ -48,4 +48,10 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: true
+  Recommendation: 
+    short: 'Colposcopy'
+    date: '2021-06-02'
+    group: 'Exception to Colposcopy Threshold (H.2)'
+    details:
+    - 'Colposcopy is recommended for all patients with HPV 16 or 18.'
 

--- a/test/ManagementHpvPanelTesting/cases/Hpv18AndUntypedNegative.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv18AndUntypedNegative.yml
@@ -48,3 +48,4 @@ results:
   NegativeOrUnknownHpvCotest: true
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: false
+  Recommendation: null

--- a/test/ManagementHpvPanelTesting/cases/Hpv18NegativeAndUntypedPositive.yml
+++ b/test/ManagementHpvPanelTesting/cases/Hpv18NegativeAndUntypedPositive.yml
@@ -48,3 +48,4 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: true
   PositiveHpv16or18Cotest: false
+  Recommendation: null

--- a/test/ManagementHpvPanelTesting/cases/HpvUnknown.yml
+++ b/test/ManagementHpvPanelTesting/cases/HpvUnknown.yml
@@ -39,3 +39,4 @@ results:
   NegativeOrUnknownHpvCotest: true
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: false
+  Recommendation: null

--- a/test/ManagementHpvPanelTesting/cases/HpvUntyped.yml
+++ b/test/ManagementHpvPanelTesting/cases/HpvUntyped.yml
@@ -41,4 +41,4 @@ results:
   NegativeOrUnknownHpvCotest: false
   PositiveUntypedHpvCotest: true
   PositiveHpv16or18Cotest: false
-
+  Recommendation: null

--- a/test/ManagementHpvPanelTesting/cases/HpvUntypedNegative.yml
+++ b/test/ManagementHpvPanelTesting/cases/HpvUntypedNegative.yml
@@ -41,4 +41,4 @@ results:
   NegativeOrUnknownHpvCotest: true
   PositiveUntypedHpvCotest: false
   PositiveHpv16or18Cotest: false
-
+  Recommendation: null

--- a/test/ManagementPostColposcopy/cases/Hpv16AgcCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16AgcCotestThenNegativeHistology.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV16 AGC Cotest Then Negative Histology
+name: HPV16 AGC Cotest Then Negative Histology - 1 Year Follow Up
 
 externalData:
 - resources

--- a/test/ManagementPostColposcopy/cases/Hpv16AgcCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16AgcCotestThenNegativeHistology.yml
@@ -1,0 +1,55 @@
+---
+name: HPV16 AGC Cotest Then Negative Histology
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+# Colposcopy Normal  
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#309162003 Normal histology findings (finding)
+  effectiveDateTime: 2021-06-01
+  
+# Colposcopy Procedure
+-
+  resourceType: Procedure
+  code: CPT#57455 Colposcopy of the cervix including upper/adjacent vagina; with biopsy(s) of the cervix
+  performedDateTime: 2021-06-01
+  status: completed
+
+# HrHPV16+
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+  status: final
+  conclusionCode:
+  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+  - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+  effectiveDateTime: 2021-05-01
+
+-
+  $iterate: *HrHpvAgcCotestCytology
+  
+results:
+  ManagementRecommendation: 
+    short: 'Surveillance 1-year follow-up'
+    date: '2022-06-01'
+    group: 'Rare Cytology (G.1.4)'
+    details:
+    - 'Cotesting at 1 and 2 years from date of most recent test is recommended.'
+    - 'If both cotests are negative, repeat cotesting at 3 years is recommended.'
+    - 'If any test is abnormal, then colposcopy is recommended.'

--- a/test/ManagementPostColposcopy/cases/Hpv16NilmCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16NilmCotestThenNegativeHistology.yml
@@ -1,0 +1,53 @@
+---
+name: HPV16 NILM Cotest Then Negative Histology
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+# Colposcopy Normal  
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#309162003 Normal histology findings (finding)
+  effectiveDateTime: 2021-06-01
+
+# Colposcopy Procedure
+-
+  resourceType: Procedure
+  code: CPT#57455 Colposcopy of the cervix including upper/adjacent vagina; with biopsy(s) of the cervix
+  performedDateTime: 2021-06-01
+  status: completed
+
+# HrHPV16+
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+  status: final
+  conclusionCode:
+  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+  - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+  effectiveDateTime: 2021-05-01
+
+-
+  $iterate: *HrHpvNilmCotestCytology
+  
+results:
+  ManagementRecommendation: 
+    short: 'Surveillance 1-year follow-up'
+    date: '2022-06-01'
+    group: '?'
+    details:
+    - '???'

--- a/test/ManagementPostColposcopy/cases/Hpv16NilmCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16NilmCotestThenNegativeHistology.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV16 NILM Cotest Then Negative Histology
+name: HPV16 NILM Cotest Then Negative Histology - 1 Year Follow Up
 
 externalData:
 - resources

--- a/test/ManagementPostColposcopy/cases/Hpv16NilmCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16NilmCotestThenNegativeHistology.yml
@@ -48,6 +48,6 @@ results:
   ManagementRecommendation: 
     short: 'Surveillance 1-year follow-up'
     date: '2022-06-01'
-    group: '?'
+    group: 'Management Surveillance (J.4)'
     details:
-    - '???'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementPostColposcopy/cases/Hpv16ThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16ThenNegativeHistology.yml
@@ -1,0 +1,54 @@
+---
+name: HPV16 Cotest Then Negative Histology
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+# Colposcopy Normal  
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#309162003 Normal histology findings (finding)
+  effectiveDateTime: 2021-06-01
+  
+# Colposcopy Procedure
+-
+  resourceType: Procedure
+  code: CPT#57455 Colposcopy of the cervix including upper/adjacent vagina; with biopsy(s) of the cervix
+  performedDateTime: 2021-06-01
+  status: completed
+
+# HrHPV16+
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+  status: final
+  conclusionCode:
+  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+  - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+  effectiveDateTime: 2021-05-01
+
+-
+  $iterate: *HrHpvCotestCytology
+  
+results:
+  ManagementRecommendation: 
+    short: 'Surveillance 1-year follow-up'
+    date: '2022-06-01'
+    group: 'Colposcopy Results (Table 3)'
+    details:
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'

--- a/test/ManagementPostColposcopy/cases/Hpv16ThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv16ThenNegativeHistology.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV16 Cotest Then Negative Histology
+name: HPV16 Cotest Then Negative Histology - 1 Year Follow Up
 
 externalData:
 - resources

--- a/test/ManagementPostColposcopy/cases/Hpv18AgcCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18AgcCotestThenNegativeHistology.yml
@@ -1,0 +1,55 @@
+---
+name: HPV18 AGC Cotest Then Negative Histology
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+# Colposcopy Normal  
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#309162003 Normal histology findings (finding)
+  effectiveDateTime: 2021-06-01
+  
+# Colposcopy Procedure
+-
+  resourceType: Procedure
+  code: CPT#57455 Colposcopy of the cervix including upper/adjacent vagina; with biopsy(s) of the cervix
+  performedDateTime: 2021-06-01
+  status: completed
+
+# HrHPV18+
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+  status: final
+  conclusionCode:
+  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+  - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+  effectiveDateTime: 2021-05-01
+
+-
+  $iterate: *HrHpvAgcCotestCytology
+  
+results:
+  ManagementRecommendation: 
+    short: 'Surveillance 1-year follow-up'
+    date: '2022-06-01'
+    group: 'Rare Cytology (G.1.4)'
+    details:
+    - 'Cotesting at 1 and 2 years from date of most recent test is recommended.'
+    - 'If both cotests are negative, repeat cotesting at 3 years is recommended.'
+    - 'If any test is abnormal, then colposcopy is recommended.'

--- a/test/ManagementPostColposcopy/cases/Hpv18AgcCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18AgcCotestThenNegativeHistology.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV18 AGC Cotest Then Negative Histology
+name: HPV18 AGC Cotest Then Negative Histology - 1 Year Follow Up
 
 externalData:
 - resources

--- a/test/ManagementPostColposcopy/cases/Hpv18NilmCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18NilmCotestThenNegativeHistology.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV18 NILM Cotest Then Negative Histology
+name: HPV18 NILM Cotest Then Negative Histology - 1 Year Follow Up
 
 externalData:
 - resources

--- a/test/ManagementPostColposcopy/cases/Hpv18NilmCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18NilmCotestThenNegativeHistology.yml
@@ -48,6 +48,6 @@ results:
   ManagementRecommendation: 
     short: 'Surveillance 1-year follow-up'
     date: '2022-06-01'
-    group: '?'
+    group: 'Management Surveillance (J.4)'
     details:
-    - '???'
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementPostColposcopy/cases/Hpv18NilmCotestThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18NilmCotestThenNegativeHistology.yml
@@ -1,0 +1,53 @@
+---
+name: HPV18 NILM Cotest Then Negative Histology
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+# Colposcopy Normal  
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#309162003 Normal histology findings (finding)
+  effectiveDateTime: 2021-06-01
+
+# Colposcopy Procedure
+-
+  resourceType: Procedure
+  code: CPT#57455 Colposcopy of the cervix including upper/adjacent vagina; with biopsy(s) of the cervix
+  performedDateTime: 2021-06-01
+  status: completed
+
+# HrHPV18+
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+  status: final
+  conclusionCode:
+  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+  - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+  effectiveDateTime: 2021-05-01
+
+-
+  $iterate: *HrHpvNilmCotestCytology
+
+results:
+  ManagementRecommendation: 
+    short: 'Surveillance 1-year follow-up'
+    date: '2022-06-01'
+    group: '?'
+    details:
+    - '???'

--- a/test/ManagementPostColposcopy/cases/Hpv18ThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18ThenNegativeHistology.yml
@@ -1,0 +1,54 @@
+---
+name: HPV18 Cotest Then Negative Histology
+
+externalData:
+- resources
+
+data:
+- 
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1996-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+# Colposcopy Normal  
+-
+  resourceType: DiagnosticReport
+  code: LOINC#65753-6 Cervix Pathology biopsy report
+  status: final
+  conclusionCode:
+  - SNOMEDCT#309162003 Normal histology findings (finding)
+  effectiveDateTime: 2021-06-01
+  
+# Colposcopy Procedure
+-
+  resourceType: Procedure
+  code: CPT#57455 Colposcopy of the cervix including upper/adjacent vagina; with biopsy(s) of the cervix
+  performedDateTime: 2021-06-01
+  status: completed
+
+# HrHPV18+
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+  status: final
+  conclusionCode:
+  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+  - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+  effectiveDateTime: 2021-05-01
+
+-
+  $iterate: *HrHpvCotestCytology
+  
+results:
+  ManagementRecommendation: 
+    short: 'Surveillance 1-year follow-up'
+    date: '2022-06-01'
+    group: 'Colposcopy Results (Table 3)'
+    details:
+    - 'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'
+    - 'If HPV testing or cotesting is not available, Pap testing may be performed. This is recommended at 6-month intervals from date of most recent test.'

--- a/test/ManagementPostColposcopy/cases/Hpv18ThenNegativeHistology.yml
+++ b/test/ManagementPostColposcopy/cases/Hpv18ThenNegativeHistology.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV18 Cotest Then Negative Histology
+name: HPV18 Cotest Then Negative Histology - 1 Year Follow Up
 
 externalData:
 - resources

--- a/test/ManagementPostColposcopy/cases/HpvUntypedNilmCin1OrLess.yml
+++ b/test/ManagementPostColposcopy/cases/HpvUntypedNilmCin1OrLess.yml
@@ -1,0 +1,53 @@
+---
+name: HPV Untyped NILM Cotest Then CIN1 or Less 
+
+externalData:
+- resources  
+    
+data:
+-
+  resourceType: Patient
+  name: Joanne Smith
+  gender: female
+  birthDate: 1980-01-01
+  extension:
+  -
+    url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    valueCode: F
+
+- 
+  $iterate: *HistologyCin1OrNormalThisYear
+      
+-
+  resourceType: DiagnosticReport
+  code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+  status: amended
+  conclusionCode:
+  - SNOMEDCT#373887005 Negative for intraepithelial lesion or malignancy (finding)
+  effectiveDateTime: 2021-04-01
+- 
+  resourceType: DiagnosticReport
+  code: LOINC#82675-0 Human papilloma virus 16+18+31+33+35+39+45+51+52+56+58+59+66+68 DNA [Presence] in Cervix by NAA with probe detection
+  status: final
+  result:
+  - reference: Observation/1234
+  conclusionCode:
+  - SNOMEDCT#260373001 Detected (qualifier value)
+  effectiveDateTime: 2021-04-01
+-
+  resourceType: Observation
+  id: 1234
+  code: LOINC#71431-1 Human papilloma virus 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Presence] in Cervix by NAA with probe detection
+  status: final
+  valueCodeableConcept: SNOMEDCT#260373001 Detected (qualifier value)
+  effectiveDateTime: 2021-04-01
+
+results:
+  HasRecentAbnormalScreening: true
+  RecommendColposcopy: false
+  ManagementRecommendation:
+    short: 'Surveillance 1-year follow-up'
+    group: 'Management Surveillance (J.4)'
+    date: '2022-05-01'
+    details:
+    -  'Primary HPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementPostColposcopy/cases/HpvUntypedNilmCin1OrLess.yml
+++ b/test/ManagementPostColposcopy/cases/HpvUntypedNilmCin1OrLess.yml
@@ -1,5 +1,5 @@
 ---
-name: HPV Untyped NILM Cotest Then CIN1 or Less 
+name: HPV Untyped NILM Cotest Then CIN1 or Less - 1 Year Follow Up
 
 externalData:
 - resources  

--- a/test/ManagementPostColposcopy/cases/resources.yml
+++ b/test/ManagementPostColposcopy/cases/resources.yml
@@ -38,3 +38,16 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#373887005 Negative for intraepithelial lesion or malignancy (finding)
     effectiveDateTime: 2021-05-01
+- &HistologyCin1OrNormalThisYear
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#285836003 Cervical intraepithelial neoplasia grade 1 (disorder)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#65753-6 Cervix Pathology biopsy report
+    status: final
+    conclusionCode:
+    - SNOMEDCT#165324008 Biopsy result normal (finding) 
+    effectiveDateTime: 2021-05-01

--- a/test/ManagementPostColposcopy/cases/resources.yml
+++ b/test/ManagementPostColposcopy/cases/resources.yml
@@ -1,0 +1,40 @@
+reusable_resources:
+- &HrHpvCotestCytology
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: amended
+    conclusionCode:
+    - SNOMEDCT#441087007 Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: amended
+    conclusionCode:
+    - SNOMEDCT#62051000119105 Low grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: amended
+    conclusionCode:
+    - SNOMEDCT#441088002 Atypical squamous cells on cervical Papanicolaou smear cannot exclude high grade squamous intraepithelial lesion (finding)
+    effectiveDateTime: 2021-05-01
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: amended
+    conclusionCode:
+    - SNOMEDCT#62061000119107 High grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding)
+    effectiveDateTime: 2021-05-01    
+- &HrHpvAgcCotestCytology
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: amended
+    conclusionCode:
+    - SNOMEDCT#441219009 Atypical glandular cells on cervical Papanicolaou smear (finding)
+    effectiveDateTime: 2021-05-01
+- &HrHpvNilmCotestCytology
+  - resourceType: DiagnosticReport
+    code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain
+    status: amended
+    conclusionCode:
+    - SNOMEDCT#373887005 Negative for intraepithelial lesion or malignancy (finding)
+    effectiveDateTime: 2021-05-01

--- a/test/ManagementPostColposcopy/cqlt.yaml
+++ b/test/ManagementPostColposcopy/cqlt.yaml
@@ -1,0 +1,13 @@
+---
+library:
+  name: ManagementLibrary
+  paths: ../../cql
+tests:
+  path: cases/
+options:
+  date: "2021-06-02T00:00:00.000Z"
+  vsac:
+    cache: .vscache
+  dumpFiles:
+    enabled: true
+    path: test_results


### PR DESCRIPTION
This anticipates changes to the logic to fix recommendations post colposcopy. 
It adds test cases of the format:
HPV16/18+ cotest followed by a negative histology
These cases should not get a colposcopy recommendation, but a 1-year follow-up recommendation. 

The HPV16/18+ & NILM case needs to be updated after CQL fixes are made to accommodate this case.