### PR TITLE
Adjust processing HPV results for risk table lookups

### DIFF
--- a/cql/AutogeneratedTableLookup.cql
+++ b/cql/AutogeneratedTableLookup.cql
@@ -184,6 +184,9 @@ define function GetSurveillanceManagement(prev2HpvVal String, prev2PapVal String
     }
 
 define function GetRowTable2(prev2HpvVal String, prev2PapVal String, prevHpvVal String, prevPapVal String, currHpvVal String, currPapVal String):
+  _GetRowTable2(AnyHpv(prev2HpvVal), prev2PapVal, AnyHpv(prevHpvVal), prevPapVal, currHpvVal, currPapVal)
+  
+define function _GetRowTable2(prev2HpvVal String, prev2PapVal String, prevHpvVal String, prevPapVal String, currHpvVal String, currPapVal String):
   Coalesce(
     Coalesce( // Case 1: Current cytology is fully specified
       SurveillanceTable T
@@ -474,6 +477,9 @@ define function GetPostColposcopyManagement(preBiopsyHpvVal String, preBiopsyPap
     }
 
 define function GetRowTable4(preBiopsyHpvVal String, preBiopsyPapVal String, biopsyVal String, prev2HpvVal String, prev2PapVal String, prevHpvVal String, prevPapVal String, currHpvVal String, currPapVal String):
+  _GetRowTable4(AnyHpv(preBiopsyHpvVal), preBiopsyPapVal, biopsyVal, prev2HpvVal, prev2PapVal, prevHpvVal, prevPapVal, AnyHpv(currHpvVal), currPapVal)
+
+define function _GetRowTable4(preBiopsyHpvVal String, preBiopsyPapVal String, biopsyVal String, prev2HpvVal String, prev2PapVal String, prevHpvVal String, prevPapVal String, currHpvVal String, currPapVal String):
   if biopsyVal = '<CIN1' or biopsyVal = 'CIN1' then
     Coalesce(
       Coalesce( // Case 1: Explicit current cytology
@@ -566,9 +572,9 @@ define function GetRowTable4(preBiopsyHpvVal String, preBiopsyPapVal String, bio
 
 define function GetAdjacentRowsTable4(preBiopsyHpvVal String, preBiopsyPapVal String, biopsyVal String, prev2HpvVal String, prev2PapVal String, prevHpvVal String, prevPapVal String, currHpvVal String, currPapVal String):
   PostColposcopyTable T
-    where T.preColposcopyResult = HighOrLowGradeResults(preBiopsyHpvVal, preBiopsyPapVal)
+    where T.preColposcopyResult = HighOrLowGradeResults(AnyHpv(preBiopsyHpvVal), preBiopsyPapVal)
       and T.postColposcopyPastHistory = PostColposcopyPastHistory(prev2HpvVal, prev2PapVal, prevHpvVal, prevPapVal)
-      and T.hpv = currHpvVal
+      and T.hpv = AnyHpv(currHpvVal)
       and T.pap != currPapVal
       return {
         action: T.management,
@@ -667,7 +673,7 @@ define function GetRowTable5(biopsyVal String, prev2HpvVal String, prev2PapVal S
     Coalesce( // Case 2: Explicit current cytology
       PostTreatmentTable T
         where T.biopsy = TreatCin2AndCin3TheSame(biopsyVal)
-          and T.hpv = currHpvVal
+          and T.hpv = AnyHpv(currHpvVal)
           and T.pap = currPapVal
           return {
             action: T.management,
@@ -687,7 +693,7 @@ define function GetRowTable5(biopsyVal String, prev2HpvVal String, prev2PapVal S
     Coalesce( // Case 3: Current cytology might be specified as 'High Grade'
       PostTreatmentTable T
         where T.biopsy = TreatCin2AndCin3TheSame(biopsyVal)
-          and T.hpv = currHpvVal
+          and T.hpv = AnyHpv(currHpvVal)
           and T.pap = HighOrLowGradeResults(currHpvVal, currPapVal)
           return {
             action: T.management,
@@ -707,7 +713,7 @@ define function GetRowTable5(biopsyVal String, prev2HpvVal String, prev2PapVal S
     Coalesce( // Case 4: Current cytology might be specified as 'ASC-US/LSIL'
       PostTreatmentTable T
         where T.biopsy = TreatCin2AndCin3TheSame(biopsyVal)
-          and T.hpv = currHpvVal
+          and T.hpv = AnyHpv(currHpvVal)
           and T.pap = AscusLsilPap(currPapVal)
           return {
             action: T.management,

--- a/cql/AutogeneratedTableLookup.json
+++ b/cql/AutogeneratedTableLookup.json
@@ -1132,7 +1132,61 @@
                }
             } ]
          }, {
-            "name" : "GetRowTable2",
+            "name" : "AnyHpv",
+            "context" : "Unfiltered",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "type" : "If",
+               "condition" : {
+                  "type" : "Equal",
+                  "operand" : [ {
+                     "name" : "hpvVal",
+                     "type" : "OperandRef"
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "HPV16+",
+                     "type" : "Literal"
+                  } ]
+               },
+               "then" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "HPV-positive",
+                  "type" : "Literal"
+               },
+               "else" : {
+                  "type" : "If",
+                  "condition" : {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "name" : "hpvVal",
+                        "type" : "OperandRef"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "HPV16-, HPV18+",
+                        "type" : "Literal"
+                     } ]
+                  },
+                  "then" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "HPV-positive",
+                     "type" : "Literal"
+                  },
+                  "else" : {
+                     "name" : "hpvVal",
+                     "type" : "OperandRef"
+                  }
+               }
+            },
+            "operand" : [ {
+               "name" : "hpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "_GetRowTable2",
             "context" : "Unfiltered",
             "accessLevel" : "Public",
             "type" : "FunctionDef",
@@ -1975,6 +2029,79 @@
                }
             } ]
          }, {
+            "name" : "GetRowTable2",
+            "context" : "Unfiltered",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "name" : "_GetRowTable2",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "name" : "AnyHpv",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "name" : "prev2HpvVal",
+                     "type" : "OperandRef"
+                  } ]
+               }, {
+                  "name" : "prev2PapVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "AnyHpv",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "name" : "prevHpvVal",
+                     "type" : "OperandRef"
+                  } ]
+               }, {
+                  "name" : "prevPapVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "currHpvVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "currPapVal",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "prev2HpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prev2PapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prevHpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prevPapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "currHpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "currPapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
             "name" : "GetSurveillanceManagement",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -2310,60 +2437,6 @@
                }
             }, {
                "name" : "currPapVal",
-               "operandTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
-               }
-            } ]
-         }, {
-            "name" : "AnyHpv",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "type" : "FunctionDef",
-            "expression" : {
-               "type" : "If",
-               "condition" : {
-                  "type" : "Equal",
-                  "operand" : [ {
-                     "name" : "hpvVal",
-                     "type" : "OperandRef"
-                  }, {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                     "value" : "HPV16+",
-                     "type" : "Literal"
-                  } ]
-               },
-               "then" : {
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "HPV-positive",
-                  "type" : "Literal"
-               },
-               "else" : {
-                  "type" : "If",
-                  "condition" : {
-                     "type" : "Equal",
-                     "operand" : [ {
-                        "name" : "hpvVal",
-                        "type" : "OperandRef"
-                     }, {
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "HPV16-, HPV18+",
-                        "type" : "Literal"
-                     } ]
-                  },
-                  "then" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                     "value" : "HPV-positive",
-                     "type" : "Literal"
-                  },
-                  "else" : {
-                     "name" : "hpvVal",
-                     "type" : "OperandRef"
-                  }
-               }
-            },
-            "operand" : [ {
-               "name" : "hpvVal",
                "operandTypeSpecifier" : {
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
@@ -3633,7 +3706,7 @@
                }
             } ]
          }, {
-            "name" : "GetRowTable4",
+            "name" : "_GetRowTable4",
             "context" : "Unfiltered",
             "accessLevel" : "Public",
             "type" : "FunctionDef",
@@ -4542,6 +4615,106 @@
                }
             } ]
          }, {
+            "name" : "GetRowTable4",
+            "context" : "Unfiltered",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "name" : "_GetRowTable4",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "name" : "AnyHpv",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "name" : "preBiopsyHpvVal",
+                     "type" : "OperandRef"
+                  } ]
+               }, {
+                  "name" : "preBiopsyPapVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "biopsyVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "prev2HpvVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "prev2PapVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "prevHpvVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "prevPapVal",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "AnyHpv",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "name" : "currHpvVal",
+                     "type" : "OperandRef"
+                  } ]
+               }, {
+                  "name" : "currPapVal",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "preBiopsyHpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "preBiopsyPapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "biopsyVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prev2HpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prev2PapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prevHpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "prevPapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "currHpvVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "currPapVal",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
             "name" : "GetPostColposcopyManagement",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -4698,8 +4871,12 @@
                               "name" : "HighOrLowGradeResults",
                               "type" : "FunctionRef",
                               "operand" : [ {
-                                 "name" : "preBiopsyHpvVal",
-                                 "type" : "OperandRef"
+                                 "name" : "AnyHpv",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "name" : "preBiopsyHpvVal",
+                                    "type" : "OperandRef"
+                                 } ]
                               }, {
                                  "name" : "preBiopsyPapVal",
                                  "type" : "OperandRef"
@@ -4736,8 +4913,12 @@
                            "scope" : "T",
                            "type" : "Property"
                         }, {
-                           "name" : "currHpvVal",
-                           "type" : "OperandRef"
+                           "name" : "AnyHpv",
+                           "type" : "FunctionRef",
+                           "operand" : [ {
+                              "name" : "currHpvVal",
+                              "type" : "OperandRef"
+                           } ]
                         } ]
                      } ]
                   }, {
@@ -5554,8 +5735,12 @@
                                  "scope" : "T",
                                  "type" : "Property"
                               }, {
-                                 "name" : "currHpvVal",
-                                 "type" : "OperandRef"
+                                 "name" : "AnyHpv",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "name" : "currHpvVal",
+                                    "type" : "OperandRef"
+                                 } ]
                               } ]
                            } ]
                         }, {
@@ -5706,8 +5891,12 @@
                                  "scope" : "T",
                                  "type" : "Property"
                               }, {
-                                 "name" : "currHpvVal",
-                                 "type" : "OperandRef"
+                                 "name" : "AnyHpv",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "name" : "currHpvVal",
+                                    "type" : "OperandRef"
+                                 } ]
                               } ]
                            } ]
                         }, {
@@ -5865,8 +6054,12 @@
                                  "scope" : "T",
                                  "type" : "Property"
                               }, {
-                                 "name" : "currHpvVal",
-                                 "type" : "OperandRef"
+                                 "name" : "AnyHpv",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "name" : "currHpvVal",
+                                    "type" : "OperandRef"
+                                 } ]
                               } ]
                            } ]
                         }, {

--- a/test/ManagementTable1/cases/resources.yml
+++ b/test/ManagementTable1/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +861,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -825,6 +889,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/ManagementTable2/cases/resources.yml
+++ b/test/ManagementTable2/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +861,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -825,6 +889,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/ManagementTable3/cases/resources.yml
+++ b/test/ManagementTable3/cases/resources.yml
@@ -750,6 +750,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -768,6 +784,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -788,6 +820,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -801,6 +849,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +877,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/ManagementTable4/cases/resources.yml
+++ b/test/ManagementTable4/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +861,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -825,6 +889,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/ManagementTable5/cases/CIN2or3ThenHpvPositiveHighGradePapColposcopyTreatment.yml
+++ b/test/ManagementTable5/cases/CIN2or3ThenHpvPositiveHighGradePapColposcopyTreatment.yml
@@ -19,12 +19,7 @@ data:
 -
   $import: *CervicalPrecancerTreatmentLastYear
 - 
-  resourceType: DiagnosticReport
-  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
-  status: final
-  conclusionCode:
-  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
-  effectiveDateTime: 2021-05-01
+  $iterate: *CurrentHpvPositiveResults
 - 
   $iterate: *CurrentHighGradePap 
 

--- a/test/ManagementTable5/cases/resources.yml
+++ b/test/ManagementTable5/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,18 +861,44 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
-- &CurrentHpvResults
-  - resourceType: DiagnosticReport
-    code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
     status: final
     conclusionCode:
-    - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
-    effectiveDateTime: 2021-05-01
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
+- &CurrentHpvPositiveResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/RarelyScreened/cases/HsilHighRiskHpv16PositiveRecentPrecancerTreatment_NotRS.yml
+++ b/test/RarelyScreened/cases/HsilHighRiskHpv16PositiveRecentPrecancerTreatment_NotRS.yml
@@ -28,11 +28,11 @@ data:
 
 results:
   Recommendation:
-    short: 'Treatment'
+    short: 'Colposcopy or Treatment'
     date: '2021-06-02'
-    group: 'General Screening (Table 1)'
+    group: 'Post Treatment (Table 5)'
     details:
-    - 'Treatment using an excisional procedure without previous biopsy confirmation is preferred, but colposcopy with biopsy is acceptable.'
+    - 'Treatment using an excisional procedure without previous biopsy confirmation OR colposcopy and biopsy are both acceptable.'
     - 'If the patient is currently pregnant, endocervical curettage, endometrial biopsy, and treatment without biopsy are unacceptable.'
-  WhichTableMadeTheRecommendation: 1
+  WhichTableMadeTheRecommendation: 5
   IsRarelyScreenedPatient: false

--- a/test/RarelyScreened/cases/HsilHighRiskHpv18PositiveRecentPrecancerTreatment_NotRS.yml
+++ b/test/RarelyScreened/cases/HsilHighRiskHpv18PositiveRecentPrecancerTreatment_NotRS.yml
@@ -30,9 +30,9 @@ results:
   Recommendation:
     short: 'Colposcopy or Treatment'
     date: '2021-06-02'
-    group: 'General Screening (Table 1)'
+    group: 'Post Treatment (Table 5)'
     details:
     - 'Treatment using an excisional procedure without previous biopsy confirmation OR colposcopy and biopsy are both acceptable.'
     - 'If the patient is currently pregnant, endocervical curettage, endometrial biopsy, and treatment without biopsy are unacceptable.'
-  WhichTableMadeTheRecommendation: 1
+  WhichTableMadeTheRecommendation: 5
   IsRarelyScreenedPatient: false

--- a/test/RarelyScreened/cases/Over50HsilHpv16PositiveOldPrecancerTreatment_RS.yml
+++ b/test/RarelyScreened/cases/Over50HsilHpv16PositiveOldPrecancerTreatment_RS.yml
@@ -35,5 +35,5 @@ results:
     details:
     - 'Treatment using an excisional procedure without previous biopsy confirmation is preferred, but colposcopy with biopsy is acceptable.'
     - 'For patients who have not been screened within the past 5 years or more, risks are higher and treatment is preferred to colposcopy to minimize loss to follow-up.'
-  WhichTableMadeTheRecommendation: 1
+  WhichTableMadeTheRecommendation: 5
   IsRarelyScreenedPatient: true

--- a/test/RarelyScreened/cases/Over50HsilHpv18PositiveOldPrecancerTreatment_RS.yml
+++ b/test/RarelyScreened/cases/Over50HsilHpv18PositiveOldPrecancerTreatment_RS.yml
@@ -35,5 +35,5 @@ results:
     details:
     - 'Treatment using an excisional procedure without previous biopsy confirmation is preferred, but colposcopy with biopsy is acceptable.'
     - 'For patients who have not been screened within the past 5 years or more, risks are higher and treatment is preferred to colposcopy to minimize loss to follow-up.'
-  WhichTableMadeTheRecommendation: 1
+  WhichTableMadeTheRecommendation: 5
   IsRarelyScreenedPatient: true

--- a/test/TopLevelManagement/cases/resources.yml
+++ b/test/TopLevelManagement/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +861,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -825,6 +889,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/WithObsManagementTable1/cases/resources.yml
+++ b/test/WithObsManagementTable1/cases/resources.yml
@@ -765,6 +765,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -783,6 +799,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -803,6 +835,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -816,6 +864,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -828,6 +892,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/WithObsManagementTable2/cases/resources.yml
+++ b/test/WithObsManagementTable2/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +861,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -825,6 +889,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/WithObsManagementTable3/cases/resources.yml
+++ b/test/WithObsManagementTable3/cases/resources.yml
@@ -756,6 +756,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -774,6 +790,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -794,6 +826,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -807,6 +855,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -819,6 +883,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/WithObsManagementTable4/cases/resources.yml
+++ b/test/WithObsManagementTable4/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,6 +861,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
 - &CurrentHpvResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -825,6 +889,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport

--- a/test/WithObsManagementTable5/cases/CIN2or3ThenHpvPositiveNilmAscusLsilColposcopy.yml
+++ b/test/WithObsManagementTable5/cases/CIN2or3ThenHpvPositiveNilmAscusLsilColposcopy.yml
@@ -19,12 +19,7 @@ data:
 -
   $import: *CervicalPrecancerTreatmentLastYear
 - 
-  resourceType: DiagnosticReport
-  code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
-  status: final
-  conclusionCode:
-  - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
-  effectiveDateTime: 2021-05-01
+  $iterate: *CurrentHpvPositiveResults
 - 
   resourceType: DiagnosticReport
   code: LOINC#10524-7 Microscopic observation [Identifier] in Cervix by Cyto stain

--- a/test/WithObsManagementTable5/cases/resources.yml
+++ b/test/WithObsManagementTable5/cases/resources.yml
@@ -762,6 +762,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2014-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2014-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
     status: final
@@ -780,6 +796,22 @@ reusable_resources:
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2017-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2017-05-01
   - resourceType: DiagnosticReport
     code: LOINC#54852-9 Any fracture related to a fall in the 6 months prior to admission [CMS Assessment]
@@ -800,6 +832,22 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2019-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2019-05-01
 - &HpvResultsOneYearAgo
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
@@ -813,18 +861,44 @@ reusable_resources:
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
     effectiveDateTime: 2020-05-01
-- &CurrentHpvResults
-  - resourceType: DiagnosticReport
-    code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
     status: final
     conclusionCode:
-    - SNOMEDCT#787724008 Human papillomavirus deoxyribonucleic acid test negative (finding)
-    effectiveDateTime: 2021-05-01
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2020-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
+    effectiveDateTime: 2020-05-01
+- &CurrentHpvPositiveResults
   - resourceType: DiagnosticReport
     code: LOINC#21440-3 Human papilloma virus 16+18+31+33+35+45+51+52+56 DNA [Presence] in Cervix by Probe
     status: final
     conclusionCode:
     - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708299006 Deoxyribonucleic acid of Human papillomavirus 18 (substance)
+    effectiveDateTime: 2021-05-01
+  - 
+    resourceType: DiagnosticReport
+    code: LOINC#77379-6 Human papilloma virus 16 and 18 and 31+33+35+39+45+51+52+56+58+59+66+68 DNA [Interpretation] in Cervix
+    status: final
+    conclusionCode:
+    - SNOMEDCT#720005005 Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)
+    - SNOMEDCT#708298003 Deoxyribonucleic acid of Human papillomavirus 16 (substance)
     effectiveDateTime: 2021-05-01
 - &AscusOrLsilSevenYearsAgo
   - resourceType: DiagnosticReport


### PR DESCRIPTION
Addressing [CCSMCDS-373](https://jira.mitre.org/browse/CCSMCDS-373)

AutogeneratedTableLookup.cql contains the functions that try to match patient history with entries in the autogenerated risk tables (AutogeneratedRiskTables.cql).

The issue encountered is that HPV results can be interpreted as four results: HPV-negative, HPV-positive, HPV16+, HPV16-,18+. Some of the lookup functions are looking only for a result that is "HPV-positive". If the result is "HPV16+", those functions may fail to see the result as a positive HPV result. 

The current lookup functions for Table 3 make use of the AnyHpv() function to treat HPV16+ and HPV16-,18+ as "HPV-positive" results. 

These changes expand on the use of the AnyHpv() function, and expand the test cases to include HPV16+ and HPV18+ results, not just non-typed hrHPV "HPV-positive".

For Table 1 lookups, there are individual rows that match HPV16+ and HPV18+. The Table 1 history does not look for HPV-positive results. Therefore, no changes are required for Table 1 lookups.

Table 2 lookups rely on the HPV history and history-prev-2, so these values are sent through AnyHpv() to recognize HPV16+ and HPV18+. Current HPV row values do have entries for HPV16+ and HPV18+

Table 3 already uses AnyHpv, so no additional changes needed.

Table 4 relies on "preColposcopyResult" so it will need to use AnyHpv()

Table 5 relies on current HPV value, so these get wrapped in AnyHpv(). LongTermSurveillance is only looking at HPV-negative results, so no change needed there. 

Test cases are expanded by adding HPV16+ and HPV18+ results to the resources.yml files that the tests are iterating over. 

The RarelyScreened Post-Treatment test cases, I believe, were erroneously giving recommendations from Table 1 instead of Table 5 because of this particular issue. 



