### PR TITLE
Coerce previous HPV results for Table 2 adjacent row lookup

### DIFF
--- a/cql/AutogeneratedTableLookup.cql
+++ b/cql/AutogeneratedTableLookup.cql
@@ -276,8 +276,8 @@ define function _GetRowTable2(prev2HpvVal String, prev2PapVal String, prevHpvVal
 
 define function GetAdjacentRowsTable2(prev2HpvVal String, prev2PapVal String, prevHpvVal String, prevPapVal String, currHpvVal String, currPapVal String):
   SurveillanceTable T
-  where T.history_prev_2 = ScreeningText(prev2HpvVal, prev2PapVal, '/', 'none')
-    and T.history = historyLeadingSpace(ScreeningText(prevHpvVal, prevPapVal, '/', 'none'))
+  where T.history_prev_2 = ScreeningText(AnyHpv(prev2HpvVal), prev2PapVal, '/', 'none')
+    and T.history = historyLeadingSpace(ScreeningText(AnyHpv(prevHpvVal), prevPapVal, '/', 'none'))
     and T.hpv = hpv18PlusAlternativeSpelling(currHpvVal)
     and T.pap != currPapVal
     return {

--- a/cql/AutogeneratedTableLookup.json
+++ b/cql/AutogeneratedTableLookup.json
@@ -2231,8 +2231,12 @@
                               "name" : "ScreeningText",
                               "type" : "FunctionRef",
                               "operand" : [ {
-                                 "name" : "prev2HpvVal",
-                                 "type" : "OperandRef"
+                                 "name" : "AnyHpv",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "name" : "prev2HpvVal",
+                                    "type" : "OperandRef"
+                                 } ]
                               }, {
                                  "name" : "prev2PapVal",
                                  "type" : "OperandRef"
@@ -2259,8 +2263,12 @@
                                  "name" : "ScreeningText",
                                  "type" : "FunctionRef",
                                  "operand" : [ {
-                                    "name" : "prevHpvVal",
-                                    "type" : "OperandRef"
+                                    "name" : "AnyHpv",
+                                    "type" : "FunctionRef",
+                                    "operand" : [ {
+                                       "name" : "prevHpvVal",
+                                       "type" : "OperandRef"
+                                    } ]
                                  }, {
                                     "name" : "prevPapVal",
                                     "type" : "OperandRef"


### PR DESCRIPTION
Needed to restore the AnyHpv() call to GetAdjacentRowsTable2 - previous HPV results needed to be coerced to "HPV-positive" to find adjacent rows if the result was HPV16+ or HPV16-,18+

Verify via inspection of ManagementTable2 result .json files and inspect the Table 2 Adjacent Rows array for cases where the previous HPV results were 16 or 18. Without the fix, they are empty arrays. 