### PR TITLE
Return referring hpv and cyto values from table3 lookups

### DIFF
--- a/cql/AutogeneratedTableLookup.cql
+++ b/cql/AutogeneratedTableLookup.cql
@@ -327,8 +327,8 @@ define function GetRowTable3(preBiopsyHpvVal String, preBiopsyPapVal String, bio
             biopsy: T.biopsy,
             preColposcopyResult: '',
             postColposcopyPastHistory: '',
-            hpv: '',
-            cyto: '',
+            hpv: preBiopsyHpvVal,
+            cyto: preBiopsyPapVal,
             riskNow: convert T.value.immediate to Decimal,
             risk5yr: convert T.value.five_year to Decimal
           }
@@ -346,8 +346,8 @@ define function GetRowTable3(preBiopsyHpvVal String, preBiopsyPapVal String, bio
             biopsy: T.biopsy,
             preColposcopyResult: '',
             postColposcopyPastHistory: '',
-            hpv: '',
-            cyto: '',
+            hpv: preBiopsyHpvVal,
+            cyto: preBiopsyPapVal,
             riskNow: convert T.value.immediate to Decimal,
             risk5yr: convert T.value.five_year to Decimal
           }
@@ -365,8 +365,8 @@ define function GetRowTable3(preBiopsyHpvVal String, preBiopsyPapVal String, bio
             biopsy: T.biopsy,
             preColposcopyResult: '',
             postColposcopyPastHistory: '',
-            hpv: '',
-            cyto: '',
+            hpv: preBiopsyHpvVal,
+            cyto: preBiopsyPapVal,
             riskNow: convert T.value.immediate to Decimal,
             risk5yr: convert T.value.five_year to Decimal
           }

--- a/cql/AutogeneratedTableLookup.json
+++ b/cql/AutogeneratedTableLookup.json
@@ -2574,16 +2574,14 @@
                            }, {
                               "name" : "hpv",
                               "value" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                 "value" : "",
-                                 "type" : "Literal"
+                                 "name" : "preBiopsyHpvVal",
+                                 "type" : "OperandRef"
                               }
                            }, {
                               "name" : "cyto",
                               "value" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                 "value" : "",
-                                 "type" : "Literal"
+                                 "name" : "preBiopsyPapVal",
+                                 "type" : "OperandRef"
                               }
                            }, {
                               "name" : "riskNow",
@@ -2715,16 +2713,14 @@
                            }, {
                               "name" : "hpv",
                               "value" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                 "value" : "",
-                                 "type" : "Literal"
+                                 "name" : "preBiopsyHpvVal",
+                                 "type" : "OperandRef"
                               }
                            }, {
                               "name" : "cyto",
                               "value" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                 "value" : "",
-                                 "type" : "Literal"
+                                 "name" : "preBiopsyPapVal",
+                                 "type" : "OperandRef"
                               }
                            }, {
                               "name" : "riskNow",
@@ -2857,16 +2853,14 @@
                            }, {
                               "name" : "hpv",
                               "value" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                 "value" : "",
-                                 "type" : "Literal"
+                                 "name" : "preBiopsyHpvVal",
+                                 "type" : "OperandRef"
                               }
                            }, {
                               "name" : "cyto",
                               "value" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                 "value" : "",
-                                 "type" : "Literal"
+                                 "name" : "preBiopsyPapVal",
+                                 "type" : "OperandRef"
                               }
                            }, {
                               "name" : "riskNow",


### PR DESCRIPTION
Table3 lookups don't return the referring HPV and Cytology result values. Add these values to be consistent with the other table lookup returns. 