### PR TITLE
Update recommendation dates for J.2 and I.4

### DIFF
--- a/cql/ManageRareAbnormality.cql
+++ b/cql/ManageRareAbnormality.cql
@@ -1521,7 +1521,7 @@ define RecommendationForHistologyResults:
     ) then
       {
         short: 'Surveillance 3-year follow-up',
-        date: Today(),
+        date: ToDate(Collate.MostRecentHpvReport.date) + 3 years,
         group: 'Managing Histology (I.4.3.2)',
         details: {
           'Primary hrHPV testing or cotesting every 3 years is recommended for at least 25 years, even if this is beyond the age of 65 years. Surveillance may continue for as long as the patient remains in good health.'
@@ -1578,7 +1578,7 @@ define RecommendationForHistologyResults:
     ) then
       {
         short: 'Surveillance 1-year follow-up',
-        date: Today(),
+        date: ToDate(Collate.MostRecentHpvReport.date) + 1 year,
         group: 'Managing Histology (I.4.3.1)',
         details: {
           'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'
@@ -2090,7 +2090,7 @@ define RecommendationForSurveillanceAfterAbnormalities:
     ) then
       {
         short: 'Surveillance 6-month follow-up',
-        date: Today(),
+        date: ToDate(MostRecentTreatmentDate) + 6 months,
         group: 'Management Surveillance (J.2.1)',
         details: {
           'Primary HPV testing or cotesting is preferred at 6 months regardless of the margin status of the excisional specimen.',
@@ -2127,7 +2127,7 @@ define RecommendationForSurveillanceAfterAbnormalities:
     ) then
       {
         short: 'Surveillance 3-year follow-up',
-        date: Today(),
+        date: ToDate(Collate.MostRecentHpvReport.date) + 3 years,
         group: 'Management Surveillance (J.3.2)',
         details: {
           'Primary HPV testing or cotesting at 3-year intervals is recommended for at least 25 years after treatment of high-grade histology.',
@@ -2142,7 +2142,7 @@ define RecommendationForSurveillanceAfterAbnormalities:
     ) then
       {
         short: 'Surveillance 3-year follow-up',
-        date: Today(),
+        date: ToDate(Collate.MostRecentHpvReport.date) + 3 years,
         group: 'Management Surveillance (J.3.2)',
         details: {
           'Continued surveillance with HPV testing or cotesting at 3-year intervals is recommended and may continue as long as the patient is in reasonably good health.'

--- a/cql/ManageRareAbnormality.json
+++ b/cql/ManageRareAbnormality.json
@@ -11931,7 +11931,23 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "type" : "Today"
+                           "type" : "Add",
+                           "operand" : [ {
+                              "type" : "ToDate",
+                              "operand" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentHpvReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           }, {
+                              "value" : 3,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
                         }
                      }, {
                         "name" : "group",
@@ -12341,7 +12357,23 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "type" : "Today"
+                           "type" : "Add",
+                           "operand" : [ {
+                              "type" : "ToDate",
+                              "operand" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentHpvReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           }, {
+                              "value" : 1,
+                              "unit" : "year",
+                              "type" : "Quantity"
+                           } ]
                         }
                      }, {
                         "name" : "group",
@@ -14604,7 +14636,18 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "type" : "Today"
+                           "type" : "Add",
+                           "operand" : [ {
+                              "type" : "ToDate",
+                              "operand" : {
+                                 "name" : "MostRecentTreatmentDate",
+                                 "type" : "ExpressionRef"
+                              }
+                           }, {
+                              "value" : 6,
+                              "unit" : "months",
+                              "type" : "Quantity"
+                           } ]
                         }
                      }, {
                         "name" : "group",
@@ -14784,7 +14827,23 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "type" : "Today"
+                           "type" : "Add",
+                           "operand" : [ {
+                              "type" : "ToDate",
+                              "operand" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentHpvReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           }, {
+                              "value" : 3,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
                         }
                      }, {
                         "name" : "group",
@@ -14857,7 +14916,23 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "type" : "Today"
+                           "type" : "Add",
+                           "operand" : [ {
+                              "type" : "ToDate",
+                              "operand" : {
+                                 "path" : "date",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "MostRecentHpvReport",
+                                    "libraryName" : "Collate",
+                                    "type" : "ExpressionRef"
+                                 }
+                              }
+                           }, {
+                              "value" : 3,
+                              "unit" : "years",
+                              "type" : "Quantity"
+                           } ]
                         }
                      }, {
                         "name" : "group",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ccsm-cds-with-tests",
-      "version": "0.5.4",
+      "version": "0.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-testing": "^2.5.3"

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegative2YearFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegative2YearFollowUp.yml
@@ -41,7 +41,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 3-year follow-up'
-    date: '2021-06-02'
+    date: '2024-05-01'
     group: 'Managing Histology (I.4.3.2)'
     details: 
       - 'Primary hrHPV testing or cotesting every 3 years is recommended for at least 25 years, even if this is beyond the age of 65 years. Surveillance may continue for as long as the patient remains in good health.'

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
@@ -34,7 +34,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 1-year follow-up'
-    date: '2021-06-02'
+    date: '2022-05-01'
     group: 'Managing Histology (I.4.3.1)'
     details: 
       - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegative2YearFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegative2YearFollowUp.yml
@@ -48,7 +48,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 3-year follow-up'
-    date: '2021-06-02'
+    date: '2024-05-01'
     group: 'Managing Histology (I.4.3.2)'
     details: 
       - 'Primary hrHPV testing or cotesting every 3 years is recommended for at least 25 years, even if this is beyond the age of 65 years. Surveillance may continue for as long as the patient remains in good health.'

--- a/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegativeFollowUp.yml
+++ b/test/ManagementHistologyResults/cases/I43HistologicLSILPrecededByHSILNegativeFollowUp.yml
@@ -42,7 +42,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 1-year follow-up'
-    date: '2021-06-02'
+    date: '2022-05-01'
     group: 'Managing Histology (I.4.3.1)'
     details: 
       - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementHistologyResults/cases/I44AscHLessThanCIN2AbnormalThenNegative.yml
+++ b/test/ManagementHistologyResults/cases/I44AscHLessThanCIN2AbnormalThenNegative.yml
@@ -88,7 +88,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 1-year follow-up'
-    date: '2021-06-02'
+    date: '2022-05-01'
     group: 'Managing Histology (I.4.3.1)'
     details:
     - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/ManagementSurveillanceAfterAbnormalities/cases/J21ShortTermFollowupAfterTreatmentWithoutPreviousBiopsy.yml
+++ b/test/ManagementSurveillanceAfterAbnormalities/cases/J21ShortTermFollowupAfterTreatmentWithoutPreviousBiopsy.yml
@@ -20,7 +20,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 6-month follow-up'
-    date: '2021-06-02'
+    date: '2021-12-01'
     group: 'Management Surveillance (J.2.1)'
     details:
     - 'Primary HPV testing or cotesting is preferred at 6 months regardless of the margin status of the excisional specimen.'

--- a/test/ManagementSurveillanceAfterAbnormalities/cases/J21ShortTermFollowupAfterTreatmentforHistologicHSIL.yml
+++ b/test/ManagementSurveillanceAfterAbnormalities/cases/J21ShortTermFollowupAfterTreatmentforHistologicHSIL.yml
@@ -22,7 +22,7 @@ data:
 results:
   Recommendation: 
     short: 'Surveillance 6-month follow-up'
-    date: '2021-06-02'
+    date: '2021-12-01'
     group: 'Management Surveillance (J.2.1)'
     details:
     - 'Primary HPV testing or cotesting is preferred at 6 months regardless of the margin status of the excisional specimen.'

--- a/test/ManagementSurveillanceAfterAbnormalities/cases/J32LongTermFollowupAfterTreatment3Tests.yml
+++ b/test/ManagementSurveillanceAfterAbnormalities/cases/J32LongTermFollowupAfterTreatment3Tests.yml
@@ -51,7 +51,7 @@ data:
 results:
   Recommendation: 
     short: 'Surveillance 3-year follow-up'
-    date: '2021-06-02'
+    date: '2023-06-01'
     group: 'Management Surveillance (J.3.2)'
     details:
     - 'Primary HPV testing or cotesting at 3-year intervals is recommended for at least 25 years after treatment of high-grade histology.'

--- a/test/ManagementSurveillanceAfterAbnormalities/cases/J32LongTermFollowupAfterTreatment4Tests.yml
+++ b/test/ManagementSurveillanceAfterAbnormalities/cases/J32LongTermFollowupAfterTreatment4Tests.yml
@@ -58,7 +58,7 @@ data:
 results:
   Recommendation: 
     short: 'Surveillance 3-year follow-up'
-    date: '2021-06-02'
+    date: '2024-06-01'
     group: 'Management Surveillance (J.3.2)'
     details:
     - 'Primary HPV testing or cotesting at 3-year intervals is recommended for at least 25 years after treatment of high-grade histology.'

--- a/test/ManagementSurveillanceAfterAbnormalities/cases/J32LongTermFollowupAfterTreatmentWithoutPreviousBiopsy.yml
+++ b/test/ManagementSurveillanceAfterAbnormalities/cases/J32LongTermFollowupAfterTreatmentWithoutPreviousBiopsy.yml
@@ -51,7 +51,7 @@ data:
 results:
   Recommendation: 
     short: 'Surveillance 3-year follow-up'
-    date: '2021-06-02'
+    date: '2024-06-01'
     group: 'Management Surveillance (J.3.2)'
     details:
     - 'Primary HPV testing or cotesting at 3-year intervals is recommended for at least 25 years after treatment of high-grade histology.'

--- a/test/ManagementSurveillanceAfterAbnormalities/cases/TreatmentOnlyThisYear.yml
+++ b/test/ManagementSurveillanceAfterAbnormalities/cases/TreatmentOnlyThisYear.yml
@@ -20,7 +20,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 6-month follow-up'
-    date: '2021-06-02'
+    date: '2021-12-01'
     group: 'Management Surveillance (J.2.1)'
     details:
     - 'Primary HPV testing or cotesting is preferred at 6 months regardless of the margin status of the excisional specimen.'

--- a/test/TopLevelManagement/cases/TreatmentThisYearNoPreviousAbnormalTests.yml
+++ b/test/TopLevelManagement/cases/TreatmentThisYearNoPreviousAbnormalTests.yml
@@ -22,7 +22,7 @@ results:
   IsIncludedAndNotExcluded: true
   ManagementRecommendation:
     short: 'Surveillance 6-month follow-up'
-    date: '2021-06-02'
+    date: '2021-12-01'
     group: 'Management Surveillance (J.2.1)'
     details:
     - 'Primary HPV testing or cotesting is preferred at 6 months regardless of the margin status of the excisional specimen.'

--- a/test/WithObsManagementHistology/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
+++ b/test/WithObsManagementHistology/cases/I43HistologicLSILPrecededByASCHNegativeFollowUp.yml
@@ -46,7 +46,7 @@ data:
 results:
   Recommendation:
     short: 'Surveillance 1-year follow-up'
-    date: '2021-06-02'
+    date: '2022-05-01'
     group: 'Managing Histology (I.4.3.1)'
     details: 
       - 'Primary hrHPV testing or cotesting is recommended in 1 year from date of most recent test.'

--- a/test/WithObsSurveillanceAfterAbnormalities/cases/J21ShortTermFollowupAfterTreatmentforHistologicHSIL.yml
+++ b/test/WithObsSurveillanceAfterAbnormalities/cases/J21ShortTermFollowupAfterTreatmentforHistologicHSIL.yml
@@ -32,7 +32,7 @@ data:
 results:
   Recommendation: 
     short: 'Surveillance 6-month follow-up'
-    date: '2021-06-02'
+    date: '2021-12-01'
     group: 'Management Surveillance (J.2.1)'
     details:
     - 'Primary HPV testing or cotesting is preferred at 6 months regardless of the margin status of the excisional specimen.'


### PR DESCRIPTION
Provide updated recommendation dates for 5.I.4.3.a and 5.I.4.3.b (1 and 3 year surveillance follow-up) and for 5.J.2.1.a (Treatment + 6 months) and 5.J.3.2.a and 5.J.3.2.b (MostRecentHpvReport.date + 3 years)
These were all previously "Today()" as recommendation date.
Updated test files to match updated dates.